### PR TITLE
fix(db): make v2_stat_user unique migration upgrade-safe (dedupe + correct safety check)

### DIFF
--- a/database/migrations/2026_06_03_000003_fix_stat_user_unique_with_record_type.php
+++ b/database/migrations/2026_06_03_000003_fix_stat_user_unique_with_record_type.php
@@ -9,17 +9,22 @@ use Illuminate\Support\Facades\Schema;
 /**
  * 修正 v2_stat_user 的 unique 约束：把 record_type 也纳入唯一键。
  *
- * 历史 schema 的 unique 是 (server_rate, user_id, record_at) —— 缺 record_type。
- * StatUserJob 在 MySQL upsert 时把 record_type 加进 $uniqueBy，但 MySQL 实际只看 schema
- * 的 unique 索引，所以同 (user_id, server_rate, record_at) 下 record_type='d' 与 ='m' 会撞库；
- * Postgres 路径 ON CONFLICT (user_id, server_rate, record_at) 也一样。
+ * 历史背景：
+ *   - 2023_03_19 初版 migration 给 v2_stat_user 建过 unique (server_rate, user_id, record_at)
+ *   - 但**很多老库（v2board 升级、二次 fork）的 v2_stat_user 表早于 2023_03_19 就存在**，
+ *     Schema::hasTable 判断为已存在跳过 create，所以那个 unique **从未真正生效**
+ *   - StatUserJob 的 upsert ON DUPLICATE KEY UPDATE 因此一直退化为纯 INSERT，
+ *     生产库里累积了大量"同 (user_id, server_rate, record_at, record_type) 4 元组完全重复"的脏数据
  *
- * 结果：daily 与 monthly 统计在同 user/server_rate/同日时会把 u/d 累加到同一行，
- * record_type 取决于先写谁，统计数据被静默错位。
+ * 本迁移设计为只做"清干净"的库的 add unique：
+ *   - 若已存在新 unique：直接 return（幂等）
+ *   - 若检测到 4 元组完全重复：**不 throw 不 ALTER**，log 后 return，
+ *     让下一个迁移 2026_06_03_000004 做 dedup + add unique
+ *   - 否则就在表已经干净时直接换 unique，与原始意图一致
  *
- * 这个迁移先检测有没有"同 (server_rate,user_id,record_at) 下多 record_type 行"的脏数据；
- * 有冲突就跳过加新 unique 并 log 警告，由运维手动 dedup 后再跑一次；没有冲突就把
- * unique 替换成 (server_rate, user_id, record_at, record_type)。
+ * ⚠️ 原始版本的 safety check 只查"3 元组下多 record_type"这种合法情况（daily 与 monthly
+ * 同时存在本来就合法），漏掉了真正的"4 元组整组重复"脏数据，结果在 user 的库上撞 1062。
+ * 这里把 check 改成检测真正会撞 ADD UNIQUE 的形态。
  */
 return new class extends Migration {
     private const TABLE = 'v2_stat_user';
@@ -35,17 +40,19 @@ return new class extends Migration {
             return;
         }
 
-        // 检查是否存在脏数据会导致新 unique 失败
-        $conflicts = DB::table(self::TABLE)
-            ->select('user_id', 'server_rate', 'record_at')
-            ->selectRaw('COUNT(DISTINCT record_type) AS types')
-            ->groupBy('user_id', 'server_rate', 'record_at')
-            ->havingRaw('COUNT(DISTINCT record_type) > 1')
+        // 检查是否存在"4 元组完全重复"的脏数据 —— 这种行会让 ADD UNIQUE 直接撞 1062。
+        // 原 check 只看 3 元组下多 record_type（这种是 daily/monthly 共存的合法情况），
+        // 漏检本场景。
+        $hasDup = DB::table(self::TABLE)
+            ->select('user_id', 'server_rate', 'record_at', 'record_type')
+            ->selectRaw('COUNT(*) AS c')
+            ->groupBy('user_id', 'server_rate', 'record_at', 'record_type')
+            ->havingRaw('COUNT(*) > 1')
             ->limit(1)
-            ->get();
+            ->exists();
 
-        if ($conflicts->isNotEmpty()) {
-            Log::warning('v2_stat_user 存在 (user_id, server_rate, record_at) 同键下多 record_type 的脏数据，跳过加 unique。请运维手动合并后重跑 migrate。');
+        if ($hasDup) {
+            Log::warning('v2_stat_user 存在 4 元组完全重复的脏数据，本迁移跳过 ADD UNIQUE，将由 2026_06_03_000004 做 dedup 后处理。');
             return;
         }
 

--- a/database/migrations/2026_06_03_000004_dedupe_stat_user_and_add_unique.php
+++ b/database/migrations/2026_06_03_000004_dedupe_stat_user_and_add_unique.php
@@ -1,0 +1,172 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Dedupe v2_stat_user + add 4-column unique。是 2026_06_03_000003 的接力。
+ *
+ * 为什么需要单独一条迁移：
+ *   - v2_stat_user 在很多老库（v2board / 二次 fork / 早于 2023_03_19 建表的部署）里
+ *     根本没有 unique 索引（2023_03_19 的 Schema::hasTable check 跳过 create）。
+ *   - StatUserJob 的 upsert ON DUPLICATE KEY 因此一直退化为纯 INSERT，
+ *     生产库累积了"同 (user_id, server_rate, record_at, record_type) 4 元组完全重复"的脏数据。
+ *   - 直接 ADD UNIQUE 会撞 1062；2026_06_03_000003 在检测到这种 dup 时主动 skip + warning，
+ *     把"清干净 + 再加 unique"的活留给本迁移完成，避免 migrate 卡住。
+ *
+ * Dedupe 策略：**每组保留 MAX(id) 那一行，其它删掉**。
+ *   - 语义：模拟"如果 UPSERT 当时能生效，最后一次写入会覆盖所有先前值"
+ *   - 不做 SUM 合并：旧 upsert 路径在不同代码版本里 u/d 的语义混杂了 increment 和 snapshot；
+ *     SUM 会错误放大流量统计，影响下游 commission/计费推断
+ *   - 不可逆：删掉的中间行无法恢复
+ *
+ * 如果运维**确定**希望 SUM 合并语义：跑 migrate 之前手动执行 SUM 合并 SQL（让 dup 行的 u/d
+ * 合并到保留的那一行），本迁移到达时已无 dup，直接走"无操作 → drop 旧 unique → add 新 unique"。
+ *
+ * 全程幂等：新 unique 已存在则 return；dedupe 完毕再 add unique；多次跑 migrate 安全。
+ */
+return new class extends Migration {
+    private const TABLE = 'v2_stat_user';
+    private const OLD_INDEX = 'server_rate_user_id_record_at';
+    private const NEW_INDEX = 'server_rate_user_id_record_at_record_type';
+
+    public function up(): void
+    {
+        if (!Schema::hasTable(self::TABLE) || !Schema::hasColumn(self::TABLE, 'record_type')) {
+            return;
+        }
+        if ($this->indexExists(self::NEW_INDEX)) {
+            // 已经被 #3 加好（fresh install 无 dup 的库）或本迁移上次已成功
+            return;
+        }
+
+        $deleted = $this->dedupeFullDuplicates();
+        if ($deleted > 0) {
+            Log::warning("v2_stat_user dedupe：删除 {$deleted} 行 4 元组完全重复（每组保留 MAX(id)）");
+        }
+
+        // 双保险：dedupe 后再次确认无 dup，避免别的并发写在 dedupe 与 ADD UNIQUE 之间又产生重复
+        $stillHasDup = DB::table(self::TABLE)
+            ->select('user_id', 'server_rate', 'record_at', 'record_type')
+            ->selectRaw('COUNT(*) AS c')
+            ->groupBy('user_id', 'server_rate', 'record_at', 'record_type')
+            ->havingRaw('COUNT(*) > 1')
+            ->limit(1)
+            ->exists();
+        if ($stillHasDup) {
+            // 罕见：可能是 dedupe SQL 跑完后又有并发上报落入旧 INSERT 路径
+            // 不 throw，下次 migrate 会再尝试；admin 也可手动暂停 horizon 后重跑
+            Log::error('v2_stat_user dedupe 后仍存在重复行（可能是并发写入），本次跳过 ADD UNIQUE。下次 migrate 会再试。');
+            return;
+        }
+
+        Schema::table(self::TABLE, function (Blueprint $t) {
+            if ($this->indexExists(self::OLD_INDEX)) {
+                $t->dropUnique(self::OLD_INDEX);
+            }
+            $t->unique(['server_rate', 'user_id', 'record_at', 'record_type'], self::NEW_INDEX);
+        });
+    }
+
+    public function down(): void
+    {
+        // 仅 drop 新 unique；dedupe 删掉的行无法恢复
+        if (Schema::hasTable(self::TABLE) && $this->indexExists(self::NEW_INDEX)) {
+            Schema::table(self::TABLE, function (Blueprint $t) {
+                $t->dropUnique(self::NEW_INDEX);
+            });
+        }
+    }
+
+    /**
+     * 按 4 元组 dedupe，保留每组 MAX(id) 那一行，返回删除行数。
+     * MySQL / MariaDB / Postgres / SQLite 各给一份 SQL，避免依赖 driver-specific 语法。
+     */
+    private function dedupeFullDuplicates(): int
+    {
+        $driver = DB::connection()->getDriverName();
+        $table = self::TABLE;
+
+        if ($driver === 'mysql' || $driver === 'mariadb') {
+            return DB::affectingStatement(
+                "DELETE s
+                 FROM {$table} s
+                 INNER JOIN (
+                   SELECT user_id, server_rate, record_at, record_type, MAX(id) AS keep_id
+                   FROM {$table}
+                   GROUP BY user_id, server_rate, record_at, record_type
+                   HAVING COUNT(*) > 1
+                 ) k
+                   ON s.user_id = k.user_id
+                  AND s.server_rate = k.server_rate
+                  AND s.record_at = k.record_at
+                  AND s.record_type = k.record_type
+                 WHERE s.id < k.keep_id"
+            );
+        }
+        if ($driver === 'pgsql') {
+            return DB::affectingStatement(
+                "DELETE FROM {$table} s
+                 USING (
+                   SELECT user_id, server_rate, record_at, record_type, MAX(id) AS keep_id
+                   FROM {$table}
+                   GROUP BY user_id, server_rate, record_at, record_type
+                   HAVING COUNT(*) > 1
+                 ) k
+                 WHERE s.user_id = k.user_id
+                   AND s.server_rate = k.server_rate
+                   AND s.record_at = k.record_at
+                   AND s.record_type = k.record_type
+                   AND s.id < k.keep_id"
+            );
+        }
+        // SQLite 兜底：删除"不在每组 MAX(id) 集合里"的行。
+        // 单组未重复时 MAX(id) = 那一行，仍在 IN 集合里，不会被删。
+        return DB::affectingStatement(
+            "DELETE FROM {$table}
+             WHERE id NOT IN (
+               SELECT MAX(id) FROM {$table}
+               GROUP BY user_id, server_rate, record_at, record_type
+             )"
+        );
+    }
+
+    private function indexExists(string $indexName): bool
+    {
+        $connection = DB::connection();
+        $driver = $connection->getDriverName();
+        $table = self::TABLE;
+
+        if ($driver === 'mysql' || $driver === 'mariadb') {
+            $count = $connection->selectOne(
+                'SELECT COUNT(1) AS c FROM information_schema.statistics
+                 WHERE table_schema = ? AND table_name = ? AND index_name = ?',
+                [$connection->getDatabaseName(), $table, $indexName]
+            );
+            return ((int) ($count->c ?? 0)) > 0;
+        }
+        if ($driver === 'pgsql') {
+            $row = $connection->selectOne(
+                'SELECT 1 AS c FROM pg_indexes WHERE tablename = ? AND indexname = ?',
+                [$table, $indexName]
+            );
+            return $row !== null;
+        }
+        if ($driver === 'sqlite') {
+            $rows = $connection->select("PRAGMA index_list(" . $connection->getPdo()->quote($table) . ")");
+            foreach ($rows as $row) {
+                if (($row->name ?? '') === $indexName) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        if (method_exists(Schema::class, 'hasIndex')) {
+            return Schema::hasIndex($table, $indexName);
+        }
+        return false;
+    }
+};


### PR DESCRIPTION
## 紧急修复

#3 在生产撞 1062，没把"4 元组完全重复"挡住。Root cause + 后续 hotfix 在 [commit msg](https://github.com/Shannon-x/Xboard-sh/commit/HEAD) 详细写了。

## 做了什么

1. **改 #3**：把"3 元组多 record_type"safety check 换成真正的"4 元组完全重复"检测；命中时 log warning + return（不 throw），让 migrate 顺利走到 #4
2. **新增 #4**：dedupe 4 元组完全重复（保留每组 MAX(id)）→ drop 旧 unique（如存在）→ add 新 unique

## 对其他人镜像的承诺

无论什么状态的库（v2board 老库 / fresh install / 已跑过 #3 失败 / 已成功），下次 `php artisan migrate` 都能跑完所有 4 个迁移**不报错**：

| 状态 | #3 行为 | #4 行为 |
|---|---|---|
| Fresh install 无 dup | 成功 add unique | 检测新 unique 已存在 → return |
| 老库无 dup 但有旧 unique | drop 旧 + add 新 | return |
| 老库有 dup（用户当前情况） | 检测到 dup → warn + return | dedupe + add unique |
| 已跑过 #3 成功 | migrations 表有记录跳过 | return |

dedupe 走最保守策略 "保留 MAX(id)"（不做 SUM 避免错误放大流量）。运维想 SUM 语义可以在 migrate **之前**手动跑 SUM SQL，#4 跑到时无 dup 可清。

## 验证

- `php -l` 两个文件都过
- DELETE SQL 分了 MySQL / Postgres / SQLite 三 driver 各一份
- 全程幂等，多次 migrate 安全

🤖 Generated with [Claude Code](https://claude.com/claude-code)
