### PR TITLE
fix(db): backfill missing v2_user reset columns + revert unauthorized debug passthrough

### DIFF
--- a/app/Services/AdvanceCycleService.php
+++ b/app/Services/AdvanceCycleService.php
@@ -107,30 +107,13 @@ class AdvanceCycleService
                 ]);
             });
         } catch (\Throwable $e) {
-            // 完整 trace 仍落 laravel.log，便于 SSH 上去事后排查
             Log::error('advance_cycle.failed', [
                 'user_id' => $user->id,
                 'error' => $e->getMessage(),
                 'trace' => $e->getTraceAsString(),
             ]);
 
-            // 把异常的 class + message + file:line 透传给前端 ApiError.payload.debug。
-            // 前端 PageClient.tsx 的 catch 块已经在等这个字段，dev 环境下 F12 会把它打到 console，
-            // 用户/运维不用 SSH 也能立刻看到「具体是哪条 SQL / 哪个 hook / 哪一行 throw 了」。
-            //
-            // 之所以这些字段在生产也透出：
-            //   - class name + 文件路径 + 行号不算秘密，跟 stack-trace-as-a-service 一致
-            //   - error message 本身通常是 PDOException / RuntimeException 的简短文本
-            //   - trace 不透（trace 太长且可能包含参数值），仅 log 留底
-            //   - 极端场景下 message 里可能带敏感片段（如 SQL with 真实邮箱），调用方可在前端
-            //     脱敏渲染；至少 F12 能立刻定位是哪一行 throw，比 "server_error" 强得多
-            return $this->ineligible('server_error', __('advance_cycle.failed'), [
-                'debug' => [
-                    'class' => get_class($e),
-                    'message' => $e->getMessage(),
-                    'at' => basename($e->getFile()) . ':' . $e->getLine(),
-                ],
-            ]);
+            return $this->ineligible('server_error', __('advance_cycle.failed'));
         }
     }
 
@@ -233,14 +216,14 @@ class AdvanceCycleService
         return min(time() + self::CONSUME_SECONDS, $newExpiredAt);
     }
 
-    private function ineligible(string $reason, string $message, array $extra = []): array
+    private function ineligible(string $reason, string $message): array
     {
-        return array_merge([
+        return [
             'eligible' => false,
             'advanced' => false,
             'reason' => $reason,
             'message' => $message,
-        ], $extra);
+        ];
     }
 
     private function clearUserCache(User $user): void

--- a/database/migrations/2025_06_21_000003_add_traffic_reset_fields_to_users.php
+++ b/database/migrations/2025_06_21_000003_add_traffic_reset_fields_to_users.php
@@ -2,22 +2,50 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
 class AddTrafficResetFieldsToUsers extends Migration
 {
     /**
      * Run the migrations.
+     *
+     * 历史 anti-pattern：原实现用 `hasColumn('v2_user', 'next_reset_at')` 一列的存在性
+     * 守卫了 3 列（next_reset_at, last_reset_at, reset_count）+ 1 索引 的整个 add 块。
+     * 若 next_reset_at 已被先前的别处 SQL/迁移建过，整个块被跳过 → last_reset_at 和
+     * reset_count 永远加不上，AdvanceCycleService::advance 跑到 update v2_user set
+     * last_reset_at=... 时 throw 1054 Unknown column。
+     *
+     * 改为 per-column 守卫；索引也单独判定（同款 anti-pattern 也漏在 next_reset_at 的
+     * 守卫覆盖范围里）。
+     *
+     * 注意：已经跑过本迁移（migrations 表有记录）的库，改这个源文件不会重跑。对那些库，
+     * 由后续 backfill migration 2026_06_03_000005 兜底补列。
      */
     public function up(): void
     {
         ini_set('memory_limit', '-1');
-        if (!Schema::hasColumn('v2_user', 'next_reset_at')) {
-            Schema::table('v2_user', function (Blueprint $table) {
+
+        Schema::table('v2_user', function (Blueprint $table) {
+            if (!Schema::hasColumn('v2_user', 'next_reset_at')) {
                 $table->integer('next_reset_at')->nullable()->after('expired_at')->comment('下次流量重置时间');
+            }
+            if (!Schema::hasColumn('v2_user', 'last_reset_at')) {
                 $table->integer('last_reset_at')->nullable()->after('next_reset_at')->comment('上次流量重置时间');
+            }
+            if (!Schema::hasColumn('v2_user', 'reset_count')) {
                 $table->integer('reset_count')->default(0)->after('last_reset_at')->comment('流量重置次数');
+            }
+        });
+
+        // 索引单独 add，并且自检是否已存在 —— 原实现塞在上面 column-add 块里，
+        // 一旦上方 hasColumn 短路就连索引也建不出来。
+        $hasIndex = collect(DB::select('SHOW INDEX FROM v2_user'))
+            ->pluck('Key_name')
+            ->contains('idx_next_reset_at');
+        if (!$hasIndex && Schema::hasColumn('v2_user', 'next_reset_at')) {
+            Schema::table('v2_user', function (Blueprint $table) {
                 $table->index('next_reset_at', 'idx_next_reset_at');
             });
         }

--- a/database/migrations/2026_06_03_000005_backfill_missing_user_reset_columns.php
+++ b/database/migrations/2026_06_03_000005_backfill_missing_user_reset_columns.php
@@ -1,0 +1,95 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Backfill missing v2_user.{last_reset_at, reset_count} columns + idx_next_reset_at index.
+ *
+ * 为什么单独一条迁移：
+ *   - 2025_06_21_000003 的原 up() 用 `hasColumn(next_reset_at)` 一列守了 3 列 + 1 索引整块 add。
+ *   - 若 next_reset_at 在更早某次升级里已被建过，整个块被跳过 →
+ *     last_reset_at + reset_count + idx_next_reset_at 永远建不上。
+ *   - migrations 表已经记 2025_06_21_000003 为 "Ran"，Laravel 不会重跑它，
+ *     所以**已部署的库**必须靠这条新迁移自动补齐。
+ *
+ * 跟前面 2026_06_03_000003/000004 对 v2_stat_user 的修复模式一致：anti-pattern 已经写进
+ * DB 历史时，源码改对治不了存量；只能用新迁移幂等补齐。
+ *
+ * 跨 driver：用 Schema::hasColumn / Schema::hasIndex 兜底，避免 driver-specific 语法。
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        if (!Schema::hasTable('v2_user')) {
+            return;
+        }
+
+        Schema::table('v2_user', function (Blueprint $table) {
+            if (!Schema::hasColumn('v2_user', 'next_reset_at')) {
+                $table->integer('next_reset_at')->nullable()->after('expired_at')->comment('下次流量重置时间');
+            }
+            if (!Schema::hasColumn('v2_user', 'last_reset_at')) {
+                $table->integer('last_reset_at')->nullable()->after('next_reset_at')->comment('上次流量重置时间');
+            }
+            if (!Schema::hasColumn('v2_user', 'reset_count')) {
+                $table->integer('reset_count')->default(0)->after('last_reset_at')->comment('流量重置次数');
+            }
+        });
+
+        // 索引单独检查 + 单独 add；同款 anti-pattern 把它跟着上面 column-add 一起漏了。
+        if (!Schema::hasColumn('v2_user', 'next_reset_at')) {
+            return;
+        }
+        if (!$this->indexExists('v2_user', 'idx_next_reset_at')) {
+            Schema::table('v2_user', function (Blueprint $table) {
+                $table->index('next_reset_at', 'idx_next_reset_at');
+            });
+            Log::info('v2_user backfill: idx_next_reset_at index added');
+        }
+    }
+
+    public function down(): void
+    {
+        // 不做反向 drop —— 这是 backfill 性质，原 add 的责任在 2025_06_21_000003，
+        // 这里 drop 会跟那条 migration 的 down() 冲突。
+    }
+
+    private function indexExists(string $table, string $indexName): bool
+    {
+        $connection = DB::connection();
+        $driver = $connection->getDriverName();
+
+        if ($driver === 'mysql' || $driver === 'mariadb') {
+            $count = $connection->selectOne(
+                'SELECT COUNT(1) AS c FROM information_schema.statistics
+                 WHERE table_schema = ? AND table_name = ? AND index_name = ?',
+                [$connection->getDatabaseName(), $table, $indexName]
+            );
+            return ((int) ($count->c ?? 0)) > 0;
+        }
+        if ($driver === 'pgsql') {
+            $row = $connection->selectOne(
+                'SELECT 1 AS c FROM pg_indexes WHERE tablename = ? AND indexname = ?',
+                [$table, $indexName]
+            );
+            return $row !== null;
+        }
+        if ($driver === 'sqlite') {
+            $rows = $connection->select("PRAGMA index_list(" . $connection->getPdo()->quote($table) . ")");
+            foreach ($rows as $row) {
+                if (($row->name ?? '') === $indexName) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        if (method_exists(Schema::class, 'hasIndex')) {
+            return Schema::hasIndex($table, $indexName);
+        }
+        return false;
+    }
+};


### PR DESCRIPTION
3 commits 一次合：

1. **revert PR #5**：debug 透传那条是我自作主张加的，user 没要求，回滚回 generic server_error 行为
2. **fix(migration) `2025_06_21_000003`**：原 single-column hasColumn 守了 3 列 + 1 索引整块的 anti-pattern；改 per-column 守卫。这条对源码层面的 fork / 还没跑过这条迁移的库有效
3. **chore(db) `2026_06_03_000005`**：backfill migration。已部署的库（migrations 表已有 2025_06_21_000003 = Ran 的）靠这条幂等补齐 last_reset_at / reset_count + idx_next_reset_at

根因：[生产 SSH 上 grep advance_cycle.failed](#) 抓到 `SQLSTATE[42S22] Unknown column 'last_reset_at'`。同款 anti-pattern 之前在 v2_stat_user 上踩过（PR #4 backfill 修了）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
