### PR TITLE
fix(observer): respect explicit next_reset_at writes to prevent advance-cycle arbitrage

### DIFF
--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -15,10 +15,28 @@ class UserObserver
 
   public function updated(User $user): void
   {
-    if ($user->isDirty(['plan_id', 'expired_at'])) {
+    // 当 plan_id 或 expired_at 发生变化时按月度规则重算 next_reset_at —— 但前提是
+    // 调用方**没有自己显式设置** next_reset_at。
+    //
+    // 反例（曾真实发生）：AdvanceCycleService::advance() 在同一次 save() 里
+    // forceFill([expired_at=新值, next_reset_at=min(now+30d, 新值)])。若 Observer
+    // 检测到 expired_at dirty 就盲目重算，会用月度锚点静默覆盖 advance 算的"30 天后"值。
+    // 后果：用户既减了到期日 30 天又能在被覆盖的 next_reset_at 到来时被 cron
+    // 重置流量，等价免费获得整月流量配额，构成套利。
+    //
+    // 守卫语义：「调用方已显式写入 next_reset_at → 尊重调用方意图，不要覆盖」。
+    // 当前全仓只有 AdvanceCycleService 同时 dirty expired_at + next_reset_at；
+    // 其它路径（OrderService 续费/新购、Admin 改 expired_at、GiftCard 加 expire_days）
+    // 都只动 expired_at 不动 next_reset_at，重算行为不受影响。
+    //
+    // 未来如有新增"合成写 expired_at + next_reset_at + save()"需求，请审视是否真的
+    // 需要绕过 Observer，必要时通过 TrafficResetService 的显式 API 推动，不要在此处放宽守卫。
+    if ($user->isDirty(['plan_id', 'expired_at']) && !$user->isDirty('next_reset_at')) {
       $this->recalculateNextResetAt($user);
     }
 
+    // NodeUserSyncJob 派发独立分支，不受上面守卫影响 —— 节点端依赖
+    // expired_at / transfer_enable / banned 等字段变化做下发，必须照常 dispatch。
     if ($user->isDirty(['group_id', 'uuid', 'speed_limit', 'device_limit', 'banned', 'expired_at', 'transfer_enable', 'u', 'd', 'plan_id'])) {
       $oldGroupId = $user->isDirty('group_id') ? $user->getOriginal('group_id') : null;
       NodeUserSyncJob::dispatch($user->id, 'updated', $oldGroupId);


### PR DESCRIPTION
## 紧急 bug fix（套利已发生）

user_id=409 在 prod ALTER TABLE 补完缺列后第一个成功 advance 的用户，立刻被这个 bug 反咬：

| 字段 | advance 写入 | DB 实际 | 差 |
|---|---|---|---|
| expired_at | 2026-08-08 | 2026-08-08 ✅ | 减 30 天对了 |
| **next_reset_at** | **2026-07-04**（advance 算的 min(now+30d, expired_at)） | **2026-06-08**（Observer 用月度锚点覆盖） | **少 26 天，cron 3 天后又会重置一次发 800 GB** |

## 修复

[app/Observers/UserObserver.php:18-20](app/Observers/UserObserver.php#L18) 一行守卫加 `&& !isDirty('next_reset_at')`。

## 验证：为什么安全

recon 已穷举全仓所有改 expired_at 的路径：
- **唯一** 同时 dirty `expired_at + next_reset_at` 的是 `AdvanceCycleService::advance` → 守卫正好放行
- 其它路径（OrderService 续费/新购/套餐变更、Admin 改 expired_at、GiftCard expire_days 奖励）只动 expired_at → 守卫照常触发重算 → 行为不变
- TrafficResetService::performReset 自己写 next_reset_at 但不动 expired_at → Observer 本来就不触发
- `NodeUserSyncJob` 派发是独立 if 分支，不受守卫影响 → 节点同步链路 0 行变化

## 已存在受害用户

不能靠这个 PR 自愈，需要 admin 跑：

```sql
-- 单点 user 409 hotfix
UPDATE v2_user
SET next_reset_at = 1783137056,    -- advance log 算的 2026-07-04 11:50:56
    updated_at    = UNIX_TIMESTAMP()
WHERE id = 409
  AND next_reset_at = 1780883879;  -- 乐观锁

-- 全表筛其它受害者
SELECT u.id, u.email, u.next_reset_at AS cur,
       CAST(JSON_UNQUOTE(JSON_EXTRACT(l.metadata,'$.new_next_reset_at')) AS UNSIGNED) AS expected
FROM v2_user u
JOIN v2_traffic_reset_logs l
  ON l.id = (SELECT MAX(l2.id) FROM v2_traffic_reset_logs l2
             WHERE l2.user_id = u.id AND l2.reset_type = 'advance_cycle')
WHERE u.next_reset_at < CAST(JSON_UNQUOTE(JSON_EXTRACT(l.metadata,'$.new_next_reset_at')) AS UNSIGNED)
  AND (u.expired_at IS NULL OR u.expired_at > UNIX_TIMESTAMP())
  AND u.banned = 0 AND u.plan_id IS NOT NULL;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
