### PR TITLE
fix(subscription): stop randomizing uTLS fingerprint for unset/string input

### DIFF
--- a/app/Utils/Helper.php
+++ b/app/Utils/Helper.php
@@ -273,19 +273,28 @@ class Helper
     
     public static function getTlsFingerprint($utls = null)
     {
-
-        if (is_array($utls) || is_object($utls)) {
+        // Only roll a real client fingerprint when uTLS is explicitly enabled.
+        // Returning a random value for unset/disabled input caused VLESS Reality
+        // subscriptions to ship a different fp= on every refresh, which broke
+        // Reality handshakes whenever the roll picked an upstream-incompatible
+        // profile (firefox/safari/ios/qq against chrome-strict dests).
+        if (is_string($utls) && $utls !== '') {
+            $fingerprint = $utls;
+        } elseif (is_array($utls) || is_object($utls)) {
             if (!data_get($utls, 'enabled')) {
                 return null;
             }
             $fingerprint = data_get($utls, 'fingerprint', 'chrome');
-            if ($fingerprint !== 'random') {
-                return $fingerprint;
-            }
+        } else {
+            return null;
         }
 
-        $fingerprints = ['chrome', 'firefox', 'safari', 'ios', 'edge', 'qq'];
-        return Arr::random($fingerprints);
+        if ($fingerprint === 'random') {
+            $fingerprints = ['chrome', 'firefox', 'safari', 'ios', 'edge'];
+            return Arr::random($fingerprints);
+        }
+
+        return $fingerprint;
     }
 
     public static function encodeURIComponent($str) {


### PR DESCRIPTION
## 问题
`Helper::getTlsFingerprint()` 在 `$utls` 为 `null`(默认值)或纯字符串时,会**掉到末尾的 `Arr::random(...)`**返回随机指纹。对 VLESS Reality 订阅,这意味着每次刷新订阅渲染出的 `fp=` 都不同;当随机抽到与 chrome-strict 目标不兼容的 profile(firefox/safari/ios/qq)时,该用户的 Reality 握手就会断,直到下次刷新碰巧抽到兼容的为止。

## 修复
仅在 uTLS **显式启用且 `fingerprint: random`** 时才随机:

| 入参 | 修复前 | 修复后 |
|---|---|---|
| `null` / 未设 | 每次随机 | `null`(稳定,不发 fp) |
| `"chrome"`(字符串) | 每次随机 | `"chrome"`(原样) |
| `['enabled'=>false]` | `null` | `null` |
| `['enabled'=>true,'fingerprint'=>'chrome']` | `chrome` | `chrome` |
| `['enabled'=>true,'fingerprint'=>'random']` | 随机 | 随机 |

注:随机池里去掉了 `qq`——注释中它属于对 chrome-strict 目标不兼容的 profile。

## 背景
该修复此前仅以宿主单文件 bind-mount(`app/Utils/Helper.php`)的形式在生产运行,**2026-06-13 compose 迁移撤掉该挂载后,行为静默回退为退化版**。本 PR 将其上游化,使其固化进镜像、不再随挂载丢失。

`php -l` 通过;运行时已验证:`getTlsFingerprint(null) === null`、字符串原样返回、显式 random 仍随机。

🤖 Generated with [Claude Code](https://claude.com/claude-code)