### PR TITLE
fix(security): 支付跨插件签名混淆(P0-1) + 迟到支付重开(P1-10) + Octane hook 累积(P1-18)

### DIFF
--- a/app/Http/Controllers/V1/Guest/PaymentController.php
+++ b/app/Http/Controllers/V1/Guest/PaymentController.php
@@ -59,8 +59,12 @@ class PaymentController extends Controller
         if (!$order) {
             return $this->fail([400202, 'order is not found']);
         }
-        if ($order->status !== Order::STATUS_PENDING)
-            return true;
+        // 迟到支付：订单已不是 PENDING（最常见是 PENDING 超 2 小时被 OrderHandleJob 自动取消后，
+        // 用户才在网关侧完成真实支付）。此前无条件 return true 静默 ACK——钱到账却不开通、不退款、
+        // 也没有任何日志。改为进入迟到支付处理：在严格安全条件下重新开通，否则转人工告警（不再静默）。
+        if ($order->status !== Order::STATUS_PENDING) {
+            return $this->handleLatePayment($order, $callbackNo, $uuid);
+        }
 
         // 回调网关必须与订单 checkout 时绑定的 payment_id 一致：
         // 防止已知某 PENDING 订单 trade_no（可枚举）后，用攻击者掌握的另一网关 uuid
@@ -91,6 +95,84 @@ class PaymentController extends Controller
         }
 
         HookManager::call('payment.notify.success', $order);
+        return true;
+    }
+
+    /**
+     * 迟到支付处理：订单已非 PENDING 时进入。
+     *
+     * - 开通中 / 已完成：真正的重复通知，幂等 ACK。
+     * - 已取消：多为超时自动取消后用户才真正付款。在严格安全前提下尝试重新开通
+     *   （见 OrderService::reopenFromCancelled 的安全闸门），不满足条件的转人工告警。
+     * - 其它状态：记录后 ACK。
+     *
+     * 所有分支都会 return true 向网关 ACK（回调签名已验过，是真实支付，无需网关重投），
+     * 但与旧实现的关键区别是：不再静默——每一种「无法自动开通」都有 error 日志 + 指标可追踪。
+     */
+    private function handleLatePayment(Order $order, $callbackNo, $uuid)
+    {
+        $status = (int) $order->status;
+
+        // 已在开通中或已完成：正常的重复回调，幂等确认。
+        if (in_array($status, [Order::STATUS_PROCESSING, Order::STATUS_COMPLETED], true)) {
+            return true;
+        }
+
+        // 非「已取消」的其它终态（如已折抵）：记录后 ACK，不自动处理。
+        if ($status !== Order::STATUS_CANCELLED) {
+            return $this->flagLatePaymentForReview($order, $callbackNo, 'unexpected_status:' . $status);
+        }
+
+        // 已取消订单收到真实支付。重开是敏感操作，这里**强制**校验回调网关与订单
+        // checkout 绑定的 payment_id 一致（不依赖全局 payment_gateway_bind 的 warn/enforce 开关）。
+        // 结合上游已完成的签名校验与 P0-1 的 method↔uuid 绑定，攻击者无法为他人订单伪造回调，
+        // 只能重开自己真实支付过的订单。payment_id 为空（历史/免费单）无法核验来源 → 转人工。
+        $payment = $uuid !== null ? Payment::where('uuid', $uuid)->first() : null;
+        if (
+            $order->payment_id === null
+            || !$payment
+            || (int) $order->payment_id !== (int) $payment->id
+        ) {
+            return $this->flagLatePaymentForReview($order, $callbackNo, 'gateway_mismatch');
+        }
+
+        $orderService = new OrderService($order);
+        $result = $orderService->reopenFromCancelled($callbackNo);
+
+        switch ($result) {
+            case 'reopened':
+                Log::info('[late-payment] 已取消订单收到真实支付，已在安全条件下重新开通', [
+                    'trade_no' => (string) $order->trade_no,
+                    'order_id' => (int) $order->id,
+                    'user_id' => (int) $order->user_id,
+                    'callback_no' => (string) $callbackNo,
+                ]);
+                PaymentMetrics::inc('order.late_paid.reopened');
+                HookManager::call('payment.notify.success', $orderService->order);
+                return true;
+            case 'duplicate':
+                return true;
+            default: // 'manual' | 'missing' | 'unexpected' | 'error'
+                return $this->flagLatePaymentForReview($order, $callbackNo, $result);
+        }
+    }
+
+    /**
+     * 标记迟到支付需人工处理：记录 error 日志 + 指标，供运营人工退款或手动开通。
+     * 仍向网关 ACK（return true）避免无意义重投，但已不再静默。
+     */
+    private function flagLatePaymentForReview(Order $order, $callbackNo, string $reason)
+    {
+        $context = [
+            'trade_no' => (string) $order->trade_no,
+            'order_id' => (int) $order->id,
+            'user_id' => (int) $order->user_id,
+            'status' => (int) $order->status,
+            'callback_no' => (string) $callbackNo,
+            'reason' => $reason,
+        ];
+        PaymentMetrics::warn('order.late_paid.manual_review', $context);
+        Log::error('[late-payment] 已取消/非常规状态订单收到真实支付，无法安全自动开通，需人工处理', $context);
         return true;
     }
 }

--- a/app/Services/OrderService.php
+++ b/app/Services/OrderService.php
@@ -480,6 +480,100 @@ class OrderService
         return true;
     }
 
+    /**
+     * 已取消订单收到真实迟到支付后，在严格安全条件下重新开通。
+     *
+     * 只自动重开「干净」订单——cancel() 唯一会反向的操作是「退还 balance_amount」和
+     * 「恢复优惠券用量」，因此对没有余额抵扣、没有优惠券、没有套餐折抵/变更的订单，
+     * cancel() 实际上没有释放任何资源，重开与它完全对称，绝不会造成少扣款或优惠券二次使用。
+     * 其余订单一律返回 'manual' 交人工处理，避免制造不一致或漏洞。
+     *
+     * 安全性说明：本方法只在回调签名已由订单绑定网关验过之后（PaymentController::handle
+     * 上游）才会被调用，且调用前已强制校验回调网关 == 订单 payment_id，因此攻击者无法为
+     * 他人订单触发重开，只能重开自己真实支付过的订单。
+     *
+     * @return string 'reopened' | 'duplicate' | 'manual' | 'missing' | 'unexpected' | 'error'
+     */
+    public function reopenFromCancelled(string $callbackNo): string
+    {
+        $tradeNo = $this->order->trade_no;
+
+        try {
+            $action = DB::transaction(function () use ($tradeNo, $callbackNo) {
+                $locked = Order::where('trade_no', $tradeNo)->lockForUpdate()->first();
+                if (!$locked) {
+                    return 'missing';
+                }
+                // 幂等：并发回调 / 网关重投时若已被翻成开通中或已完成，视为重复通知。
+                if (in_array((int) $locked->status, [Order::STATUS_PROCESSING, Order::STATUS_COMPLETED], true)) {
+                    return 'duplicate';
+                }
+                // 只对「已取消」重开；其余状态不在本方法处理范围。
+                if ((int) $locked->status !== Order::STATUS_CANCELLED) {
+                    return 'unexpected';
+                }
+
+                // 安全闸门 A：只重开「干净」订单。
+                //   balance_amount：cancel() 已退回用户余额，重开需重新扣除，但余额可能已被花掉 → 人工。
+                //   coupon_id：    cancel() 已恢复优惠券用量，重开需重新占用，但券可能已过期/用尽 → 人工。
+                //   surplus/UPGRADE：套餐折抵/变更依赖创建时快照，此刻可能已陈旧 → 人工。
+                if (
+                    (int) ($locked->balance_amount ?? 0) !== 0
+                    || $locked->coupon_id !== null
+                    || !empty($locked->surplus_order_ids)
+                    || (int) $locked->type === Order::TYPE_UPGRADE
+                ) {
+                    return 'manual';
+                }
+
+                // 安全闸门 B：该订单取消后用户又已完成/开通更晚的订单，重开会覆盖其当前订阅 → 人工。
+                $hasNewerActiveOrder = Order::where('user_id', $locked->user_id)
+                    ->where('id', '>', $locked->id)
+                    ->whereIn('status', [Order::STATUS_PROCESSING, Order::STATUS_COMPLETED])
+                    ->exists();
+                if ($hasNewerActiveOrder) {
+                    return 'manual';
+                }
+
+                // 安全闸门 C：套餐仍存在。
+                if (!Plan::find($locked->plan_id)) {
+                    return 'manual';
+                }
+
+                $locked->status = Order::STATUS_PROCESSING;
+                $locked->paid_at = time();
+                $locked->callback_no = $callbackNo;
+                if (!$locked->save()) {
+                    throw new \RuntimeException('order save failed');
+                }
+                $this->order = $locked;
+                return 'reopened';
+            });
+        } catch (\Throwable $e) {
+            Log::error('OrderService::reopenFromCancelled transaction failed', [
+                'trade_no' => $tradeNo,
+                'message' => $e->getMessage(),
+            ]);
+            PaymentMetrics::inc('order.late_paid.exception');
+            return 'error';
+        }
+
+        if ($action === 'reopened') {
+            try {
+                OrderHandleJob::dispatchSync($tradeNo); // 复用既有开通流程（PROCESSING → open()）
+            } catch (\Throwable $e) {
+                Log::error('OrderService::reopenFromCancelled open failed', [
+                    'trade_no' => $tradeNo,
+                    'message' => $e->getMessage(),
+                ]);
+                PaymentMetrics::inc('order.late_paid.open_failed');
+                return 'error';
+            }
+        }
+
+        return $action;
+    }
+
     public function cancel(): bool
     {
         $order = $this->order;

--- a/app/Services/PaymentService.php
+++ b/app/Services/PaymentService.php
@@ -36,6 +36,13 @@ class PaymentService
             if (!$paymentModel) {
                 throw new ApiException('payment not found');
             }
+            // 安全校验：回调 URL 里的支付方式（$method）必须与 uuid 记录存储的方式一致。
+            // 否则可用 A 网关的插件去验签 B 网关的 config——当 B 的 config 缺少 A 所需的
+            // 签名密钥字段时，验签会退化为对明文参数做 md5，可被伪造（跨插件签名混淆）。
+            // 合法回调的 method 与 uuid 同源、恒相等；大小写不敏感以兼容网关对 URL 的大小写归一化。
+            if (strcasecmp((string) $paymentModel->payment, (string) $method) !== 0) {
+                throw new ApiException('payment method mismatch');
+            }
             $payment = $paymentModel->makeVisible('config')->toArray();
         }
 

--- a/config/octane.php
+++ b/config/octane.php
@@ -132,7 +132,15 @@ return [
     ],
 
     'flush' => [
-        \App\Services\Plugin\HookManager::class,
+        // HookManager 把 action/filter 回调存进容器实例 hook.actions / hook.filters
+        // （见 HookManager::setActions/getActions 里的 App::instance('hook.actions', ...)）。
+        // 之前这里 flush 的是 HookManager::class——一个全静态、从不被解析为实例的绑定，
+        // 等于空操作：scoped 的 PluginManager 每请求重新注册钩子，但这两个数组从不清理，
+        // 闭包按 spl_object_hash 无限累积（重复触发 hook + worker 内存泄漏直至 OOM）。
+        // 改为 flush 真正的存储键：每请求开始清空，随后 InitializePlugins 中间件重新注册，
+        // 保证每个 hook 每请求恰好一份。
+        'hook.actions',
+        'hook.filters',
     ],
 
     /*

--- a/tests/Feature/LatePaymentReopenTest.php
+++ b/tests/Feature/LatePaymentReopenTest.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Order;
+use App\Models\Plan;
+use App\Models\User;
+use App\Services\OrderService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+/**
+ * P1-10 回归测试：已取消订单收到真实迟到支付时的**安全**重开。
+ *
+ * 安全边界（OrderService::reopenFromCancelled）：只自动重开「干净」订单——
+ * cancel() 唯一会反向的操作是退还 balance_amount、恢复优惠券用量，因此只有
+ * 没有余额抵扣 / 没有优惠券 / 没有套餐折抵 / 非套餐变更的订单，cancel 时才没有释放
+ * 任何资源，重开与之完全对称、不会造成少扣款或优惠券二次使用。其余一律转人工，
+ * 绝不自动开通（避免制造漏洞）。本测试锁定这些拒绝闸门 + 幂等 + 正向重开。
+ */
+class LatePaymentReopenTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private int $userSeq = 0;
+
+    private function makeUser(array $overrides = []): User
+    {
+        $this->userSeq++;
+        return User::create(array_merge([
+            'email' => "late-pay-{$this->userSeq}@example.com",
+            'password' => 'x',
+            'uuid' => Str::uuid()->toString(),
+            'token' => Str::random(32),
+            'balance' => 0,
+            'plan_id' => null,
+            'group_id' => null,
+            'expired_at' => 0,
+            'transfer_enable' => 0,
+        ], $overrides));
+    }
+
+    private function makeCancelledOrder(array $overrides = []): Order
+    {
+        return Order::create(array_merge([
+            'user_id' => $this->makeUser()->id,
+            'plan_id' => 1,
+            'payment_id' => 1,
+            'period' => Plan::PERIOD_MONTHLY,
+            'trade_no' => Str::upper(Str::random(16)),
+            'total_amount' => 1000,
+            'type' => Order::TYPE_NEW_PURCHASE,
+            'status' => Order::STATUS_CANCELLED,
+        ], $overrides));
+    }
+
+    private function reopen(Order $order): string
+    {
+        return (new OrderService($order))->reopenFromCancelled('CB-' . Str::random(8));
+    }
+
+    // ---- 安全闸门 A：非「干净」订单一律转人工，不自动重开 ----
+
+    public function test_reopen_rejects_order_with_balance_amount(): void
+    {
+        // 余额抵扣已在 cancel 时退回用户，重开需重新扣除但余额可能已花掉 → 人工
+        $order = $this->makeCancelledOrder(['balance_amount' => 500]);
+
+        $this->assertSame('manual', $this->reopen($order));
+        $this->assertSame(Order::STATUS_CANCELLED, (int) $order->fresh()->status);
+    }
+
+    public function test_reopen_rejects_order_with_coupon(): void
+    {
+        // 优惠券用量已在 cancel 时恢复，重开需重新占用但券可能已过期/用尽 → 人工
+        $order = $this->makeCancelledOrder(['coupon_id' => 7]);
+
+        $this->assertSame('manual', $this->reopen($order));
+        $this->assertSame(Order::STATUS_CANCELLED, (int) $order->fresh()->status);
+    }
+
+    public function test_reopen_rejects_order_with_surplus(): void
+    {
+        // 套餐折抵依赖创建时快照，此刻可能已陈旧 → 人工
+        $order = $this->makeCancelledOrder(['surplus_order_ids' => [10, 11]]);
+
+        $this->assertSame('manual', $this->reopen($order));
+        $this->assertSame(Order::STATUS_CANCELLED, (int) $order->fresh()->status);
+    }
+
+    public function test_reopen_rejects_plan_change_order(): void
+    {
+        // 套餐变更（UPGRADE）逻辑复杂且依赖旧订阅状态 → 人工
+        $order = $this->makeCancelledOrder(['type' => Order::TYPE_UPGRADE]);
+
+        $this->assertSame('manual', $this->reopen($order));
+        $this->assertSame(Order::STATUS_CANCELLED, (int) $order->fresh()->status);
+    }
+
+    // ---- 安全闸门 B：用户已有更晚的开通/完成订单，重开会覆盖当前订阅 → 人工 ----
+
+    public function test_reopen_rejects_when_user_has_newer_active_order(): void
+    {
+        $user = $this->makeUser();
+        $cancelled = $this->makeCancelledOrder(['user_id' => $user->id]);
+        // 更晚（id 更大）且已完成的订单
+        Order::create([
+            'user_id' => $user->id,
+            'plan_id' => 1,
+            'period' => Plan::PERIOD_MONTHLY,
+            'trade_no' => Str::upper(Str::random(16)),
+            'total_amount' => 1000,
+            'type' => Order::TYPE_NEW_PURCHASE,
+            'status' => Order::STATUS_COMPLETED,
+        ]);
+
+        $this->assertSame('manual', $this->reopen($cancelled));
+        $this->assertSame(Order::STATUS_CANCELLED, (int) $cancelled->fresh()->status);
+    }
+
+    // ---- 幂等 / 状态守卫 ----
+
+    public function test_reopen_is_idempotent_for_completed_order(): void
+    {
+        $order = $this->makeCancelledOrder(['status' => Order::STATUS_COMPLETED]);
+
+        $this->assertSame('duplicate', $this->reopen($order));
+    }
+
+    public function test_reopen_returns_unexpected_for_non_cancelled_status(): void
+    {
+        $order = $this->makeCancelledOrder(['status' => Order::STATUS_DISCOUNTED]);
+
+        $this->assertSame('unexpected', $this->reopen($order));
+        $this->assertSame(Order::STATUS_DISCOUNTED, (int) $order->fresh()->status);
+    }
+
+    // ---- 正向：干净的新购订单在安全条件下被重新开通 ----
+
+    public function test_reopen_activates_clean_order(): void
+    {
+        $plan = Plan::create([
+            'group_id' => 1,
+            'transfer_enable' => 100,
+            'name' => 'Test Plan',
+            'speed_limit' => null,
+            'device_limit' => null,
+            'reset_traffic_method' => 2, // 不重置，避免测试触及周期重置细节
+        ]);
+        $user = $this->makeUser(['plan_id' => null, 'expired_at' => 0]);
+
+        $order = $this->makeCancelledOrder([
+            'user_id' => $user->id,
+            'plan_id' => $plan->id,
+            'type' => Order::TYPE_NEW_PURCHASE,
+            'balance_amount' => 0,
+            'coupon_id' => null,
+        ]);
+
+        $result = $this->reopen($order);
+
+        $this->assertSame('reopened', $result);
+        $this->assertSame(Order::STATUS_COMPLETED, (int) $order->fresh()->status);
+
+        $user->refresh();
+        $this->assertSame($plan->id, (int) $user->plan_id);
+        $this->assertGreaterThan(time(), (int) $user->expired_at);
+    }
+}

--- a/tests/Feature/PaymentMethodBindingTest.php
+++ b/tests/Feature/PaymentMethodBindingTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Exceptions\ApiException;
+use App\Models\Payment;
+use App\Services\PaymentService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+/**
+ * P0-1 回归测试：支付回调 URL 里的支付方式（method）必须与 uuid 记录存储的方式一致。
+ *
+ * 漏洞：/payment/notify/{method}/{uuid} 之前用 uuid 取 config、却用 URL 的 method 选插件，
+ * 两者不校验一致性。攻击者用一个 config 缺少目标插件签名密钥字段的网关 uuid，配合
+ * 另一网关的 method，可让验签退化为 md5(明文参数) 从而伪造支付成功。
+ *
+ * 修复：PaymentService 构造函数在 uuid 分支强制 strcasecmp(payment, method) === 0，
+ * 不符即抛 ApiException('payment method mismatch')。大小写不敏感以兼容网关对 URL 的归一化。
+ */
+class PaymentMethodBindingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makePayment(string $method, array $config = []): Payment
+    {
+        return Payment::create([
+            'uuid' => Str::random(32),
+            'payment' => $method,
+            'name' => $method . ' Gateway',
+            'icon' => null,
+            'config' => $config,
+            'enable' => true,
+        ]);
+    }
+
+    public function test_notify_rejects_method_uuid_mismatch(): void
+    {
+        // uuid 指向 EPay 记录，但回调 URL 的 method 是 Mgate（跨插件混淆攻击）
+        $payment = $this->makePayment('EPay', ['key' => 'epay-secret']);
+
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessage('payment method mismatch');
+
+        new PaymentService('Mgate', null, $payment->uuid);
+    }
+
+    public function test_notify_allows_exact_method_match(): void
+    {
+        // 合法回调：method 与 uuid 记录的 payment 完全一致，绝不能抛「方法不匹配」
+        $payment = $this->makePayment('EPay', ['key' => 'epay-secret']);
+
+        $this->assertMismatchNotThrownFor('EPay', $payment->uuid);
+    }
+
+    public function test_notify_allows_case_insensitive_method_match(): void
+    {
+        // 兼容网关对 URL 路径大小写归一化：epay 应视为与 EPay 一致，不得误伤合法回调
+        $payment = $this->makePayment('EPay', ['key' => 'epay-secret']);
+
+        $this->assertMismatchNotThrownFor('epay', $payment->uuid);
+    }
+
+    public function test_notify_rejects_unknown_uuid(): void
+    {
+        // 保留既有行为：uuid 不存在时抛 payment not found（在方法校验之前）
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessage('payment not found');
+
+        new PaymentService('EPay', null, Str::random(32));
+    }
+
+    /**
+     * 断言：给定 method/uuid 组合不会因「方法不匹配」被拒。
+     *
+     * 构造函数在通过一致性校验后会继续走插件查找；测试环境未启用任何支付插件，
+     * 后续步骤可能因找不到插件类而抛其它异常——这与本安全校验无关。因此这里只断言
+     * 「若抛异常，其消息不得是 payment method mismatch」，即校验没有误伤合法组合。
+     */
+    private function assertMismatchNotThrownFor(string $method, string $uuid): void
+    {
+        try {
+            new PaymentService($method, null, $uuid);
+            $this->assertTrue(true); // 构造成功同样满足预期
+        } catch (\Throwable $e) {
+            $this->assertStringNotContainsString(
+                'payment method mismatch',
+                $e->getMessage(),
+                '合法的 method/uuid 组合被一致性校验误拒'
+            );
+        }
+    }
+}


### PR DESCRIPTION
本 PR 修复安全审计中确认属实的三项问题，均**不含**数据库迁移 / env / 前端契约改动。

## P0-1 支付回调跨插件签名混淆（高危）
`/payment/notify/{method}/{uuid}` 之前用 uuid 取网关 config、却用 URL 的 method 选插件而不校验一致性，可让一个网关插件用另一个网关的 config 验签、退化为可伪造的明文签名。修复：`PaymentService` 构造函数强制 method 与 uuid 记录的支付方式一致（大小写不敏感，只作用于回调路径，合法回调零影响）。

## P1-10 已取消订单迟到支付被静默吞没
订单超时自动取消后用户才真正付款时，回调之前无条件 ACK：钱到账却不开通、不退款、无日志。新增 `OrderService::reopenFromCancelled`，在严格安全闸门下自动重开「干净」订单，其余转人工告警（Log::error + PaymentMetrics）。安全保证：强制校验回调网关 == 订单 payment_id，结合签名校验与 P0-1 使攻击者只能重开自己真实付款的订单；带余额抵扣 / 优惠券 / 套餐折抵 / 存在更晚订单等一律不自动开通。

## P1-18 Octane 下 HookManager 回调无界累积
`config/octane.php` 的 flush 之前配的是空操作绑定，导致每请求重新注册的钩子无限累积（重复通知 + worker 内存泄漏）。改为 flush 真实存储键 `hook.actions` / `hook.filters`。

## 测试
- `tests/Feature/PaymentMethodBindingTest.php`（P0-1）
- `tests/Feature/LatePaymentReopenTest.php`（P1-10，覆盖各安全闸门 / 幂等 / 正向重开）

## 部署
Octane 下需 `octane:reload` 生效（`config/octane.php` 若开了 config 缓存需先 `config:clear`）。无迁移、无 env 改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)