### PR TITLE
chore(gitignore): 忽略安全审计报告，防止误提交到公开仓库

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ tmp_repos/
 
 # Claude Code per-user settings
 /.claude/
+
+# 安全审计报告：含未修复漏洞的利用细节，公开仓库禁止入库
+docs/AUDIT_REPORT_*.md


### PR DESCRIPTION
`docs/AUDIT_REPORT_*.md` 含未修复漏洞（P1-2 节点令牌、P1-13 Mgate TLS 等）的利用细节，公开仓库禁止入库。加入 `.gitignore` 防止 `git add .` 误提交。

🤖 Generated with [Claude Code](https://claude.com/claude-code)