### PR TITLE
fix(device): reconcile Redis state with database snapshots

### DIFF
--- a/app/Console/Commands/NodeWebSocketServer.php
+++ b/app/Console/Commands/NodeWebSocketServer.php
@@ -206,9 +206,6 @@ class NodeWebSocketServer extends Command
 
                 $service = app(DeviceStateService::class);
                 $affectedUserIds = $service->clearAllNodeDevices($nodeId);
-                foreach ($affectedUserIds as $userId) {
-                    $service->notifyUpdate($userId);
-                }
 
                 Log::debug("[WS] Node#{$nodeId} disconnected", [
                     'total' => NodeRegistry::count(),
@@ -250,30 +247,7 @@ class NodeWebSocketServer extends Command
     private function handleDeviceReport(int $nodeId, array $data): void
     {
         $service = app(DeviceStateService::class);
-
-        // Get old data for this node
-        $oldDevices = $service->getNodeDevices($nodeId);
-
-        // Calculate diff: find users that were connected but are no longer
-        $removedUsers = array_diff_key($oldDevices, $data);
-        $newDevices = [];
-
-        foreach ($data as $userId => $ips) {
-            if (is_numeric($userId) && is_array($ips)) {
-                $newDevices[(int) $userId] = $ips;
-            }
-        }
-
-        // Handle removed users — clean their device data and update online_count
-        foreach ($removedUsers as $userId => $ips) {
-            $service->removeNodeDevices($nodeId, $userId);
-            $service->notifyUpdate($userId);
-        }
-
-        // Handle new/updated users
-        foreach ($newDevices as $userId => $ips) {
-            $service->setDevices($userId, $nodeId, $ips);
-        }
+        $service->syncNodeDevices($nodeId, $data);
 
         // 标记该节点待推送（由定时器批量处理）
         Redis::sadd('device:push_pending_nodes', $nodeId);

--- a/app/Console/Commands/ReconcileDeviceOnlineCounts.php
+++ b/app/Console/Commands/ReconcileDeviceOnlineCounts.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Services\DeviceStateService;
+use Illuminate\Console\Command;
+
+class ReconcileDeviceOnlineCounts extends Command
+{
+    protected $signature = 'device:reconcile-online-counts {--chunk=500 : Database rows per Redis pipeline}';
+
+    protected $description = 'Reconcile v2_user.online_count with real-time Redis device state';
+
+    public function handle(DeviceStateService $deviceStateService): int
+    {
+        $chunkSize = filter_var($this->option('chunk'), FILTER_VALIDATE_INT, [
+            'options' => ['min_range' => 1, 'max_range' => 5000],
+        ]);
+
+        if ($chunkSize === false) {
+            $this->error('The --chunk option must be an integer between 1 and 5000.');
+            return self::INVALID;
+        }
+
+        $updated = $deviceStateService->reconcileOnlineCounts($chunkSize);
+        $this->info("Reconciled {$updated} user online count(s).");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -39,6 +39,11 @@ class Kernel extends ConsoleKernel
         // reset
         $schedule->command('reset:traffic')->everyMinute()->onOneServer()->withoutOverlapping(10);
         $schedule->command('reset:log')->daily()->onOneServer();
+        // Redis TTL expiration does not execute PHP, so reconcile the DB display snapshot.
+        $schedule->command('device:reconcile-online-counts')
+            ->everyMinute()
+            ->onOneServer()
+            ->withoutOverlapping(5);
         // send
         $schedule->command('send:remindMail', ['--force'])->dailyAt('11:30')->onOneServer();
         // horizon metrics

--- a/app/Http/Controllers/V1/Server/UniProxyController.php
+++ b/app/Http/Controllers/V1/Server/UniProxyController.php
@@ -117,15 +117,13 @@ class UniProxyController extends Controller
     {
         $node = $this->getNodeInfo($request);
         $data = json_decode(request()->getContent(), true);
-        if ($data === null) {
+        if (!is_array($data)) {
             return response()->json([
                 'error' => 'Invalid online data'
             ], 400);
         }
 
-        foreach ($data as $uid => $ips) {
-            $this->deviceStateService->setDevices((int) $uid, $node->id, $ips);
-        }
+        $this->deviceStateService->syncNodeDevices($node->id, $data);
 
         return response()->json(['data' => true]);
     }

--- a/app/Http/Controllers/V2/Server/ServerController.php
+++ b/app/Http/Controllers/V2/Server/ServerController.php
@@ -78,11 +78,9 @@ class ServerController extends Controller
 
         // handle alive data
         $alive = $request->input('alive');
-        if (is_array($alive) && !empty($alive)) {
+        if (array_key_exists('alive', $request->all()) && is_array($alive)) {
             $deviceStateService = app(DeviceStateService::class);
-            foreach ($alive as $uid => $ips) {
-                $deviceStateService->setDevices((int) $uid, $nodeId, (array) $ips);
-            }
+            $deviceStateService->syncNodeDevices($nodeId, $alive);
         }
 
         // handle active connections

--- a/app/Services/DeviceStateService.php
+++ b/app/Services/DeviceStateService.php
@@ -44,6 +44,40 @@ class DeviceStateService
     }
 
     /**
+     * Apply a node's full device snapshot.
+     *
+     * HTTP and WebSocket reports have the same semantics: users omitted from
+     * the new snapshot are no longer online on this node. Keeping the diff in
+     * one place prevents the two transports from drifting apart.
+     *
+     * @return int[] user IDs removed from this node
+     */
+    public function syncNodeDevices(int $nodeId, array $devices): array
+    {
+        $normalized = [];
+        foreach ($devices as $userId => $ips) {
+            if (!is_numeric($userId) || (int) $userId <= 0 || !is_array($ips)) {
+                continue;
+            }
+            $normalized[(int) $userId] = $ips;
+        }
+
+        $oldDevices = $this->getNodeDevices($nodeId);
+        $removedUsers = array_diff_key($oldDevices, $normalized);
+
+        foreach (array_keys($removedUsers) as $userId) {
+            $this->removeNodeDevices($nodeId, (int) $userId);
+            $this->notifyUpdate((int) $userId);
+        }
+
+        foreach ($normalized as $userId => $ips) {
+            $this->setDevices($userId, $nodeId, $ips);
+        }
+
+        return array_map('intval', array_keys($removedUsers));
+    }
+
+    /**
      * 获取某节点的所有设备数据
      * 返回: {userId: [ip1, ip2, ...], ...}
      *
@@ -159,15 +193,94 @@ class DeviceStateService
     public function getDeviceCount(int $userId): int
     {
         $data = Redis::hgetall(self::PREFIX . $userId);
-        $now = time();
         $mode = (int) admin_setting('device_limit_mode', 0);
 
+        return $this->countDeviceData($data, $mode, time());
+    }
+
+    /**
+     * Get multiple users' real-time counts with one Redis round trip.
+     *
+     * @return array<int, int> map of user ID to current device count
+     */
+    public function getDeviceCounts(array $userIds): array
+    {
+        $userIds = array_values(array_unique(array_filter(
+            array_map('intval', $userIds),
+            fn (int $userId) => $userId > 0
+        )));
+        if (empty($userIds)) {
+            return [];
+        }
+
+        $hashes = Redis::pipeline(function ($pipe) use ($userIds) {
+            foreach ($userIds as $userId) {
+                $pipe->hgetall(self::PREFIX . $userId);
+            }
+        });
+
+        $mode = (int) admin_setting('device_limit_mode', 0);
+        $now = time();
+        $result = [];
+        foreach ($userIds as $index => $userId) {
+            $data = $hashes[$index] ?? [];
+            $result[$userId] = $this->countDeviceData(is_array($data) ? $data : [], $mode, $now);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Reconcile the database display snapshot against Redis.
+     *
+     * Redis expires device hashes without executing application code, so a
+     * positive v2_user.online_count can otherwise live forever. We scan rows
+     * that are positive or were recently touched, pipeline their Redis reads,
+     * and only write rows whose count actually changed.
+     */
+    public function reconcileOnlineCounts(int $chunkSize = 500): int
+    {
+        $chunkSize = max(1, min($chunkSize, 5000));
+        $updated = 0;
+        $recentThreshold = now()->subSeconds(self::TTL + 60);
+
+        User::query()
+            ->where(function ($query) use ($recentThreshold) {
+                $query->where('online_count', '>', 0)
+                    ->orWhere('last_online_at', '>=', $recentThreshold);
+            })
+            ->select(['id', 'online_count'])
+            ->chunkById($chunkSize, function ($users) use (&$updated) {
+                $counts = $this->getDeviceCounts($users->pluck('id')->all());
+                $idsByCount = [];
+
+                foreach ($users as $user) {
+                    $count = $counts[(int) $user->id] ?? 0;
+                    if ((int) $user->online_count === $count) {
+                        continue;
+                    }
+                    $idsByCount[$count][] = (int) $user->id;
+                    $updated++;
+                }
+
+                foreach ($idsByCount as $count => $userIds) {
+                    User::query()
+                        ->whereKey($userIds)
+                        ->update(['online_count' => (int) $count]);
+                }
+            });
+
+        return $updated;
+    }
+
+    private function countDeviceData(array $data, int $mode, int $now): int
+    {
         if ($mode === 1 || $mode === 2) {
             // Loose mode (1): deduplicate by exact IP across all nodes
             // Subnet mode (2): deduplicate by IP subnet (/24 or /64) across all nodes
             $ips = [];
             foreach ($data as $field => $timestamp) {
-                if ($now - $timestamp <= self::TTL) {
+                if ($now - (int) $timestamp <= self::TTL) {
                     $ip = substr($field, strpos($field, ':') + 1);
                     if ($mode === 2) {
                         $ip = self::getSubnet($ip);
@@ -181,7 +294,7 @@ class DeviceStateService
         // Strict mode (default): count all active entries (each node×IP pair counts separately)
         $count = 0;
         foreach ($data as $field => $timestamp) {
-            if ($now - $timestamp <= self::TTL) {
+            if ($now - (int) $timestamp <= self::TTL) {
                 $count++;
             }
         }
@@ -198,10 +311,10 @@ class DeviceStateService
         }
 
         $result = [];
-        foreach ($users as $user) {
-            $count = $this->getDeviceCount($user->id);
+        $counts = $this->getDeviceCounts($users->pluck('id')->all());
+        foreach ($counts as $userId => $count) {
             if ($count > 0) {
-                $result[$user->id] = $count;
+                $result[$userId] = $count;
             }
         }
 
@@ -220,7 +333,7 @@ class DeviceStateService
             if (!empty($data)) {
                 $ips = [];
                 foreach ($data as $field => $timestamp) {
-                    if ($now - $timestamp <= self::TTL) {
+                    if ($now - (int) $timestamp <= self::TTL) {
                         $ips[] = substr($field, strpos($field, ':') + 1);
                     }
                 }

--- a/docs/en/development/device-limit.md
+++ b/docs/en/development/device-limit.md
@@ -1,176 +1,90 @@
-# Online Device Limit Design
+# Online Device Limit
 
-## Overview
+## Data sources
 
-This document describes the design and implementation of the online device limit feature in Xboard.
+The device-limit feature deliberately separates configuration, real-time state,
+and reporting data:
 
-## Design Goals
+| Data | Source | Purpose |
+| --- | --- | --- |
+| `v2_user.device_limit` | Database | The configured maximum number of devices for a user |
+| `user_devices:{userId}` | Redis | The authoritative real-time online device state |
+| `v2_user.online_count` | Database | An eventually consistent snapshot for the admin UI and statistics |
 
-1. Accurate Control
-   - Precise counting of online devices
-   - Real-time monitoring of device status
-   - Accurate device identification
+`online_count` is not used to accept or reject a connection. A compatible node
+receives `device_limit` in the user list and obtains the current count from the
+panel's `/alivelist` endpoint. The node compares those two values when a new IP
+connects.
 
-2. Performance Optimization
-   - Minimal impact on system performance
-   - Efficient device tracking
-   - Optimized resource usage
+## Redis representation
 
-3. User Experience
-   - Smooth connection experience
-   - Clear error messages
-   - Graceful handling of limit exceeded cases
+`DeviceStateService` stores a Redis hash per user:
 
-## Implementation Details
-
-### 1. Device Identification
-
-#### Device ID Generation
-```php
-public function generateDeviceId($user, $request) {
-    return md5(
-        $user->id . 
-        $request->header('User-Agent') . 
-        $request->ip()
-    );
-}
+```text
+user_devices:{userId}
+  {nodeId}:{normalizedIp} => last_report_unix_timestamp
 ```
 
-#### Device Information Storage
-```php
-[
-    'device_id' => 'unique_device_hash',
-    'user_id' => 123,
-    'ip' => '192.168.1.1',
-    'user_agent' => 'Mozilla/5.0...',
-    'last_active' => '2024-03-21 10:00:00'
-]
+The hash TTL is 300 seconds. Timestamps are also checked while reading, so a
+stale field is not counted even if another node refreshes the hash TTL.
+
+Each node also has a reverse index:
+
+```text
+user_devices:node:{nodeId} => SET<userId>
 ```
 
-### 2. Connection Management
+This lets the panel calculate full-snapshot differences and clear a disconnected
+node without using Redis `KEYS`, which would block a shared Redis instance.
 
-#### Connection Check
-```php
-public function checkDeviceLimit($user, $deviceId) {
-    $onlineDevices = $this->getOnlineDevices($user->id);
-    
-    if (count($onlineDevices) >= $user->device_limit) {
-        if (!in_array($deviceId, $onlineDevices)) {
-            throw new DeviceLimitExceededException();
-        }
-    }
-    
-    return true;
-}
+The `device_limit_mode` setting controls counting:
+
+- `0`: strict, count every node and IP pair.
+- `1`: deduplicate the exact same IP across nodes.
+- `2`: deduplicate IPv4 `/24` or IPv6 `/64` subnets across nodes.
+
+## Report and enforcement flow
+
+1. The user list endpoint reads `device_limit` from `v2_user` and sends it to the
+   node.
+2. Nodes periodically submit a full `{userId: [ip, ...]}` device snapshot via
+   HTTP `/alive`, the V2 combined report, or WebSocket `report.devices`.
+3. The panel applies a per-node difference: users missing from the new snapshot
+   are removed from that node, and present users are replaced with the new IPs.
+4. `/alivelist` reads Redis and returns only current, non-expired counts.
+5. The node rejects a new IP when the database-configured `device_limit` has
+   already been reached by the Redis-derived alive count.
+
+A missing `alive` field in a combined report means "no device data was included"
+and does not clear state. An explicitly empty object or array is a full empty
+snapshot and clears the reporting node's state.
+
+## Database snapshot convergence
+
+Redis expiration is passive: when a key reaches its TTL, Redis does not execute
+PHP and therefore cannot directly set `v2_user.online_count` to zero. To keep the
+admin snapshot accurate, two mechanisms are used:
+
+- Device reports call `notifyUpdate()`, which mirrors the current Redis count to
+  the database with a 10-second write throttle.
+- `device:reconcile-online-counts` runs every minute. It checks rows whose stored
+  count is positive or which were recently active, fetches Redis hashes in
+  batches with a pipeline, and updates only counts that differ.
+
+The Laravel scheduler must be running in production. A typical cron entry is:
+
+```cron
+* * * * * cd /path/to/xboard && php artisan schedule:run >> /dev/null 2>&1
 ```
 
-#### Device Status Update
-```php
-public function updateDeviceStatus($userId, $deviceId) {
-    Redis::hset(
-        "user:{$userId}:devices",
-        $deviceId,
-        json_encode([
-            'last_active' => now(),
-            'status' => 'online'
-        ])
-    );
-}
+If the scheduler is stopped, device enforcement still uses Redis and remains
+correct, but `online_count` in the admin UI can retain an old positive value
+after Redis expires. Restarting the scheduler or manually running the following
+command repairs those snapshots:
+
+```bash
+php artisan device:reconcile-online-counts
 ```
 
-### 3. Cleanup Mechanism
-
-#### Inactive Device Cleanup
-```php
-public function cleanupInactiveDevices() {
-    $inactiveThreshold = now()->subMinutes(30);
-    
-    foreach ($this->getUsers() as $user) {
-        $devices = $this->getOnlineDevices($user->id);
-        
-        foreach ($devices as $deviceId => $info) {
-            if ($info['last_active'] < $inactiveThreshold) {
-                $this->removeDevice($user->id, $deviceId);
-            }
-        }
-    }
-}
-```
-
-## Error Handling
-
-### Error Types
-1. Device Limit Exceeded
-   ```php
-   class DeviceLimitExceededException extends Exception {
-       protected $message = 'Device limit exceeded';
-       protected $code = 4001;
-   }
-   ```
-
-2. Invalid Device
-   ```php
-   class InvalidDeviceException extends Exception {
-       protected $message = 'Invalid device';
-       protected $code = 4002;
-   }
-   ```
-
-### Error Messages
-```php
-return [
-    'device_limit_exceeded' => 'Maximum number of devices reached',
-    'invalid_device' => 'Device not recognized',
-    'device_expired' => 'Device session expired'
-];
-```
-
-## Performance Considerations
-
-1. Cache Strategy
-   - Use Redis for device tracking
-   - Implement cache expiration
-   - Optimize cache structure
-
-2. Database Operations
-   - Minimize database queries
-   - Use batch operations
-   - Implement query optimization
-
-3. Memory Management
-   - Efficient data structure
-   - Regular cleanup of expired data
-   - Memory usage monitoring
-
-## Security Measures
-
-1. Device Verification
-   - Validate device information
-   - Check for suspicious patterns
-   - Implement rate limiting
-
-2. Data Protection
-   - Encrypt sensitive information
-   - Implement access control
-   - Regular security audits
-
-## Future Improvements
-
-1. Enhanced Features
-   - Device management interface
-   - Device activity history
-   - Custom device names
-
-2. Performance Optimization
-   - Improved caching strategy
-   - Better cleanup mechanism
-   - Reduced memory usage
-
-3. Security Enhancements
-   - Advanced device fingerprinting
-   - Fraud detection
-   - Improved encryption
-
-## Conclusion
-
-This design provides a robust and efficient solution for managing online device limits while maintaining good performance and user experience. Regular monitoring and updates will ensure the system remains effective and secure. 
+The optional `--chunk` value controls database rows per Redis pipeline and must
+be between 1 and 5000 (default: 500).

--- a/tests/Feature/DeviceStateConsistencyTest.php
+++ b/tests/Feature/DeviceStateConsistencyTest.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Controllers\V1\Server\UniProxyController;
+use App\Http\Controllers\V2\Server\ServerController;
+use App\Services\DeviceStateService;
+use App\Services\Plugin\PluginManager;
+use App\Support\Setting;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Redis;
+use Illuminate\Support\Facades\Schema;
+use Mockery;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class DeviceStateConsistencyTest extends TestCase
+{
+    #[Test]
+    public function the_database_reconciliation_is_scheduled_every_minute(): void
+    {
+        $pluginManager = Mockery::mock(PluginManager::class);
+        $pluginManager->shouldReceive('registerPluginSchedules')->once();
+        $this->app->instance(PluginManager::class, $pluginManager);
+
+        $schedule = $this->app->make(\App\Console\Kernel::class)->resolveConsoleSchedule();
+        $event = collect($schedule->events())->first(
+            fn ($event) => str_contains($event->command ?? '', 'device:reconcile-online-counts')
+        );
+
+        $this->assertNotNull($event);
+        $this->assertSame('* * * * *', $event->expression);
+    }
+
+    #[Test]
+    public function the_reconciliation_command_passes_the_validated_chunk_size(): void
+    {
+        $service = $this->getMockBuilder(DeviceStateService::class)
+            ->onlyMethods(['reconcileOnlineCounts'])
+            ->getMock();
+        $service->expects($this->once())
+            ->method('reconcileOnlineCounts')
+            ->with(123)
+            ->willReturn(2);
+        $this->app->instance(DeviceStateService::class, $service);
+
+        $this->artisan('device:reconcile-online-counts', ['--chunk' => 123])
+            ->expectsOutput('Reconciled 2 user online count(s).')
+            ->assertSuccessful();
+    }
+
+    #[Test]
+    public function it_applies_full_node_snapshots_and_removes_missing_users(): void
+    {
+        $service = $this->getMockBuilder(DeviceStateService::class)
+            ->onlyMethods(['getNodeDevices', 'removeNodeDevices', 'notifyUpdate', 'setDevices'])
+            ->getMock();
+
+        $service->expects($this->once())
+            ->method('getNodeDevices')
+            ->with(7)
+            ->willReturn([
+                10 => ['1.1.1.1'],
+                20 => ['2.2.2.2'],
+            ]);
+        $service->expects($this->once())->method('removeNodeDevices')->with(7, 20);
+        $service->expects($this->once())->method('notifyUpdate')->with(20);
+
+        $setCalls = [];
+        $service->expects($this->exactly(2))
+            ->method('setDevices')
+            ->willReturnCallback(function (int $userId, int $nodeId, array $ips) use (&$setCalls): void {
+                $setCalls[] = [$userId, $nodeId, $ips];
+            });
+
+        $removed = $service->syncNodeDevices(7, [
+            10 => ['1.1.1.1'],
+            30 => ['3.3.3.3'],
+            'invalid' => ['4.4.4.4'],
+        ]);
+
+        $this->assertSame([20], $removed);
+        $this->assertSame([
+            [10, 7, ['1.1.1.1']],
+            [30, 7, ['3.3.3.3']],
+        ], $setCalls);
+    }
+
+    #[Test]
+    public function v1_alive_treats_an_empty_object_as_a_full_empty_snapshot(): void
+    {
+        $service = Mockery::mock(DeviceStateService::class);
+        $service->shouldReceive('syncNodeDevices')->once()->with(7, []);
+
+        $request = Request::create('/api/v1/server/UniProxy/alive', 'POST', [], [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], '{}');
+        $request->attributes->set('node_info', (object) ['id' => 7]);
+        $this->app->instance('request', $request);
+
+        $response = (new UniProxyController($service))->alive($request);
+
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function v2_report_distinguishes_a_missing_alive_field_from_an_empty_snapshot(): void
+    {
+        $service = Mockery::mock(DeviceStateService::class);
+        $service->shouldReceive('syncNodeDevices')->once()->with(7, []);
+        $this->app->instance(DeviceStateService::class, $service);
+
+        $missingRequest = Request::create('/api/v2/server/node/report', 'POST', [], [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], '{}');
+        $missingRequest->attributes->set('node_info', (object) ['id' => 7, 'type' => 'v2ray']);
+        $missingResponse = (new ServerController())->report($missingRequest);
+
+        $request = Request::create('/api/v2/server/node/report', 'POST', [], [], [], [
+            'CONTENT_TYPE' => 'application/json',
+        ], '{"alive":[]}');
+        $request->attributes->set('node_info', (object) ['id' => 7, 'type' => 'v2ray']);
+
+        $response = (new ServerController())->report($request);
+
+        $this->assertSame(200, $missingResponse->getStatusCode());
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function it_batches_redis_reads_and_ignores_expired_device_fields(): void
+    {
+        $setting = Mockery::mock(Setting::class);
+        $setting->shouldReceive('get')->once()->with('device_limit_mode')->andReturn(null);
+        $this->app->instance(Setting::class, $setting);
+
+        $now = time();
+        Redis::shouldReceive('pipeline')
+            ->once()
+            ->with(Mockery::type(\Closure::class))
+            ->andReturn([
+                [
+                    '1:1.1.1.1' => $now,
+                    '2:2.2.2.2' => $now - 30,
+                    '3:3.3.3.3' => $now - 301,
+                ],
+                [],
+            ]);
+
+        $counts = (new DeviceStateService())->getDeviceCounts([10, 20]);
+
+        $this->assertSame([10 => 2, 20 => 0], $counts);
+    }
+
+    #[Test]
+    public function it_reconciles_stale_and_recent_database_snapshots_with_redis(): void
+    {
+        config(['database.connections.sqlite.database' => ':memory:']);
+        DB::purge('sqlite');
+
+        Schema::create('v2_user', function (Blueprint $table): void {
+            $table->increments('id');
+            $table->integer('online_count')->nullable();
+            $table->timestamp('last_online_at')->nullable();
+            $table->integer('created_at')->nullable();
+            $table->integer('updated_at')->nullable();
+        });
+
+        try {
+            DB::table('v2_user')->insert([
+                ['id' => 1, 'online_count' => 18, 'last_online_at' => now()->subDay(), 'created_at' => 0, 'updated_at' => 0],
+                ['id' => 2, 'online_count' => 0, 'last_online_at' => now(), 'created_at' => 0, 'updated_at' => 0],
+                ['id' => 3, 'online_count' => 0, 'last_online_at' => now()->subDay(), 'created_at' => 0, 'updated_at' => 0],
+                ['id' => 4, 'online_count' => 3, 'last_online_at' => now(), 'created_at' => 0, 'updated_at' => 0],
+            ]);
+
+            $service = $this->getMockBuilder(DeviceStateService::class)
+                ->onlyMethods(['getDeviceCounts'])
+                ->getMock();
+            $service->expects($this->once())
+                ->method('getDeviceCounts')
+                ->with([1, 2, 4])
+                ->willReturn([1 => 0, 2 => 2, 4 => 3]);
+
+            $updated = $service->reconcileOnlineCounts();
+
+            $this->assertSame(2, $updated);
+            $this->assertSame([1 => 0, 2 => 2, 3 => 0, 4 => 3], DB::table('v2_user')
+                ->orderBy('id')
+                ->pluck('online_count', 'id')
+                ->mapWithKeys(fn ($count, $id) => [(int) $id => (int) $count])
+                ->all());
+        } finally {
+            Schema::dropIfExists('v2_user');
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- unify HTTP and WebSocket full-device snapshot handling, including explicit empty snapshots
- reconcile stale `v2_user.online_count` values against Redis every minute using chunked/pipelined reads
- batch `/alivelist` Redis reads and document the real database/Redis enforcement flow

## Root cause
Redis expires `user_devices:{userId}` without executing PHP, so the database display snapshot could stay positive forever. HTTP reports also did not diff users missing from a node snapshot, and compatible nodes do not send an empty report when every user goes offline.

## Enforcement source
The configured threshold remains `v2_user.device_limit`; the current online count remains Redis-derived through `/alivelist`. `v2_user.online_count` is only an eventually consistent admin/statistics snapshot and is not used to reject connections.

## Verification
- `./vendor/bin/phpunit --filter DeviceStateConsistencyTest` (7 tests, 26 assertions)
- PHPStan on the new command and changed HTTP controllers
- `git diff --check`

The repository-wide legacy suite is not a clean gate in this checkout: an existing `OrderPlanChangeTest` boots Eloquent without a Laravel container, and several Feature tests wait on unavailable local Redis/MySQL services.