### PR TITLE
feat(device): 上报后立即返回实时设备数

### DIFF
--- a/app/Http/Controllers/V1/Server/UniProxyController.php
+++ b/app/Http/Controllers/V1/Server/UniProxyController.php
@@ -123,9 +123,14 @@ class UniProxyController extends Controller
             ], 400);
         }
 
-        $this->deviceStateService->syncNodeDevices($node->id, $data);
+        $affectedUserIds = $this->deviceStateService->syncNodeDevices($node->id, $data);
+        $alive = $this->deviceStateService->getDeviceCounts($affectedUserIds);
 
-        return response()->json(['data' => true]);
+        return response()->json([
+            'data' => true,
+            // Post-snapshot delta lets V2bX recover without waiting for its next pull.
+            'alive' => (object) $alive,
+        ]);
     }
 
     // 提交节点负载状态

--- a/app/Http/Controllers/V2/Server/ServerController.php
+++ b/app/Http/Controllers/V2/Server/ServerController.php
@@ -78,9 +78,11 @@ class ServerController extends Controller
 
         // handle alive data
         $alive = $request->input('alive');
+        $aliveDelta = null;
         if (array_key_exists('alive', $request->all()) && is_array($alive)) {
             $deviceStateService = app(DeviceStateService::class);
-            $deviceStateService->syncNodeDevices($nodeId, $alive);
+            $affectedUserIds = $deviceStateService->syncNodeDevices($nodeId, $alive);
+            $aliveDelta = $deviceStateService->getDeviceCounts($affectedUserIds);
         }
 
         // handle active connections
@@ -127,6 +129,10 @@ class ServerController extends Controller
             ServerService::updateMetrics($node, $metrics);
         }
 
-        return response()->json(['data' => true]);
+        $response = ['data' => true];
+        if ($aliveDelta !== null) {
+            $response['alive'] = (object) $aliveDelta;
+        }
+        return response()->json($response);
     }
 }

--- a/app/Services/DeviceStateService.php
+++ b/app/Services/DeviceStateService.php
@@ -50,7 +50,7 @@ class DeviceStateService
      * the new snapshot are no longer online on this node. Keeping the diff in
      * one place prevents the two transports from drifting apart.
      *
-     * @return int[] user IDs removed from this node
+     * @return int[] user IDs whose global count may have changed
      */
     public function syncNodeDevices(int $nodeId, array $devices): array
     {
@@ -64,6 +64,10 @@ class DeviceStateService
 
         $oldDevices = $this->getNodeDevices($nodeId);
         $removedUsers = array_diff_key($oldDevices, $normalized);
+        $affectedUserIds = array_values(array_unique(array_merge(
+            array_map('intval', array_keys($oldDevices)),
+            array_map('intval', array_keys($normalized))
+        )));
 
         foreach (array_keys($removedUsers) as $userId) {
             $this->removeNodeDevices($nodeId, (int) $userId);
@@ -74,7 +78,7 @@ class DeviceStateService
             $this->setDevices($userId, $nodeId, $ips);
         }
 
-        return array_map('intval', array_keys($removedUsers));
+        return $affectedUserIds;
     }
 
     /**

--- a/docs/en/development/device-limit.md
+++ b/docs/en/development/device-limit.md
@@ -43,6 +43,12 @@ The `device_limit_mode` setting controls counting:
 - `1`: deduplicate the exact same IP across nodes.
 - `2`: deduplicate IPv4 `/24` or IPv6 `/64` subnets across nodes.
 
+For the common "test every node at once" case, mode `1` is normally the right
+choice: one physical client behind one public IP remains one device even while
+it opens connections to many nodes. Mode `0` intentionally treats those node
+connections as separate devices and can therefore exhaust the limit during an
+all-node speed test.
+
 ## Report and enforcement flow
 
 1. The user list endpoint reads `device_limit` from `v2_user` and sends it to the
@@ -51,7 +57,9 @@ The `device_limit_mode` setting controls counting:
    HTTP `/alive`, the V2 combined report, or WebSocket `report.devices`.
 3. The panel applies a per-node difference: users missing from the new snapshot
    are removed from that node, and present users are replaced with the new IPs.
-4. `/alivelist` reads Redis and returns only current, non-expired counts.
+4. The report response includes the latest Redis count for every affected user,
+   including explicit zeroes. V2bX applies this delta immediately; `/alivelist`
+   remains the periodic full-state fallback.
 5. The node rejects a new IP when the database-configured `device_limit` has
    already been reached by the Redis-derived alive count.
 

--- a/tests/Feature/DeviceStateConsistencyTest.php
+++ b/tests/Feature/DeviceStateConsistencyTest.php
@@ -52,7 +52,7 @@ class DeviceStateConsistencyTest extends TestCase
     }
 
     #[Test]
-    public function it_applies_full_node_snapshots_and_removes_missing_users(): void
+    public function it_applies_full_node_snapshots_and_returns_all_affected_users(): void
     {
         $service = $this->getMockBuilder(DeviceStateService::class)
             ->onlyMethods(['getNodeDevices', 'removeNodeDevices', 'notifyUpdate', 'setDevices'])
@@ -75,13 +75,13 @@ class DeviceStateConsistencyTest extends TestCase
                 $setCalls[] = [$userId, $nodeId, $ips];
             });
 
-        $removed = $service->syncNodeDevices(7, [
+        $affected = $service->syncNodeDevices(7, [
             10 => ['1.1.1.1'],
             30 => ['3.3.3.3'],
             'invalid' => ['4.4.4.4'],
         ]);
 
-        $this->assertSame([20], $removed);
+        $this->assertSame([10, 20, 30], $affected);
         $this->assertSame([
             [10, 7, ['1.1.1.1']],
             [30, 7, ['3.3.3.3']],
@@ -92,7 +92,8 @@ class DeviceStateConsistencyTest extends TestCase
     public function v1_alive_treats_an_empty_object_as_a_full_empty_snapshot(): void
     {
         $service = Mockery::mock(DeviceStateService::class);
-        $service->shouldReceive('syncNodeDevices')->once()->with(7, []);
+        $service->shouldReceive('syncNodeDevices')->once()->with(7, [])->andReturn([20]);
+        $service->shouldReceive('getDeviceCounts')->once()->with([20])->andReturn([20 => 0]);
 
         $request = Request::create('/api/v1/server/UniProxy/alive', 'POST', [], [], [], [
             'CONTENT_TYPE' => 'application/json',
@@ -103,13 +104,15 @@ class DeviceStateConsistencyTest extends TestCase
         $response = (new UniProxyController($service))->alive($request);
 
         $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(['data' => true, 'alive' => ['20' => 0]], $response->getData(true));
     }
 
     #[Test]
     public function v2_report_distinguishes_a_missing_alive_field_from_an_empty_snapshot(): void
     {
         $service = Mockery::mock(DeviceStateService::class);
-        $service->shouldReceive('syncNodeDevices')->once()->with(7, []);
+        $service->shouldReceive('syncNodeDevices')->once()->with(7, [])->andReturn([20]);
+        $service->shouldReceive('getDeviceCounts')->once()->with([20])->andReturn([20 => 0]);
         $this->app->instance(DeviceStateService::class, $service);
 
         $missingRequest = Request::create('/api/v2/server/node/report', 'POST', [], [], [], [
@@ -127,6 +130,8 @@ class DeviceStateConsistencyTest extends TestCase
 
         $this->assertSame(200, $missingResponse->getStatusCode());
         $this->assertSame(200, $response->getStatusCode());
+        $this->assertArrayNotHasKey('alive', $missingResponse->getData(true));
+        $this->assertSame(['20' => 0], $response->getData(true)['alive']);
     }
 
     #[Test]


### PR DESCRIPTION
## 变更
- 设备快照同步返回所有受影响用户 ID
- V1 `/alive` 与 V2 合并上报在响应中返回 Redis 最新计数增量（包含 0）
- V2bX 可据此立即解除已经不再需要的设备限制，不必等待下一次 `/alivelist` 拉取
- 文档明确全节点测速场景下 strict/loose 模式差异

## 兼容性
新增响应字段，旧节点会自动忽略；原接口状态码与 `data: true` 保持不变。

## 验证
- `phpunit --filter DeviceStateConsistencyTest`：7 tests / 31 assertions
- 相关控制器 PHPStan 通过
- PHP 语法与 diff 检查通过