### PR TITLE
fix(payment): 迟到支付复活复核后放行 + 双重折抵守卫 + TG 告警 + 同商户通道等价

### DIFF
--- a/app/Http/Controllers/V1/Guest/PaymentController.php
+++ b/app/Http/Controllers/V1/Guest/PaymentController.php
@@ -7,6 +7,7 @@ use App\Models\Order;
 use App\Models\Payment;
 use App\Services\OrderService;
 use App\Services\PaymentService;
+use App\Services\TelegramService;
 use App\Support\FeatureFlag;
 use App\Support\PaymentMetrics;
 use Illuminate\Http\Request;
@@ -78,12 +79,18 @@ class PaymentController extends Controller
         if ($bindMode !== 'off' && $uuid !== null && $order->payment_id !== null) {
             $payment = Payment::where('uuid', $uuid)->first();
             if ($payment && (int) $order->payment_id !== (int) $payment->id) {
+                // 同插件类的不同网关记录视为同源（如同一易支付商户拆的「支付宝」「微信」
+                // 两条通道：用户 checkout 后切换支付方式会改写 payment_id，随后才支付
+                // 第一条通道的收款码，合法回调必然与最终绑定不一致）。enforce 只拦跨插件。
+                $boundPayment = Payment::find($order->payment_id);
+                $sameFamily = $boundPayment && (string) $boundPayment->payment === (string) $payment->payment;
                 PaymentMetrics::warn('webhook.payment_id_mismatch', [
                     'trade_no' => $tradeNo,
                     'order_payment_id' => (int) $order->payment_id,
                     'callback_payment_id' => (int) $payment->id,
+                    'same_family' => $sameFamily,
                 ]);
-                if ($bindMode === 'enforce') {
+                if ($bindMode === 'enforce' && !$sameFamily) {
                     return false;
                 }
             }
@@ -124,16 +131,28 @@ class PaymentController extends Controller
         }
 
         // 已取消订单收到真实支付。重开是敏感操作，这里**强制**校验回调网关与订单
-        // checkout 绑定的 payment_id 一致（不依赖全局 payment_gateway_bind 的 warn/enforce 开关）。
-        // 结合上游已完成的签名校验与 P0-1 的 method↔uuid 绑定，攻击者无法为他人订单伪造回调，
-        // 只能重开自己真实支付过的订单。payment_id 为空（历史/免费单）无法核验来源 → 转人工。
+        // checkout 绑定的 payment_id 同源（不依赖全局 payment_gateway_bind 的 warn/enforce 开关）：
+        //   - 精确同一网关记录 → 通过；
+        //   - 同一插件类的不同网关记录（如同一易支付商户拆的「支付宝」「微信」两条通道，
+        //     用户 checkout 后切换过支付方式导致 payment_id 指向另一条）→ 视为同源放行，
+        //     单独记指标便于观察；
+        //   - 跨插件 / 无绑定 / 找不到回调网关 → 转人工。
+        // 回调签名已在上游用接收 uuid 的凭证验过，是该网关的真实结算通知；同插件类等价
+        // 不弱于 pending 路径默认 warn 模式的既有行为（后者对跨网关回调仅记录不拒收）。
         $payment = $uuid !== null ? Payment::where('uuid', $uuid)->first() : null;
-        if (
-            $order->payment_id === null
-            || !$payment
-            || (int) $order->payment_id !== (int) $payment->id
-        ) {
+        $boundPayment = $order->payment_id !== null ? Payment::find($order->payment_id) : null;
+        if (!$payment || !$boundPayment) {
             return $this->flagLatePaymentForReview($order, $callbackNo, 'gateway_mismatch');
+        }
+        if ((int) $boundPayment->id !== (int) $payment->id) {
+            if ((string) $boundPayment->payment !== (string) $payment->payment) {
+                return $this->flagLatePaymentForReview($order, $callbackNo, 'gateway_mismatch');
+            }
+            PaymentMetrics::warn('order.late_paid.gateway_family_match', [
+                'trade_no' => (string) $order->trade_no,
+                'order_payment_id' => (int) $boundPayment->id,
+                'callback_payment_id' => (int) $payment->id,
+            ]);
         }
 
         $orderService = new OrderService($order);
@@ -148,6 +167,7 @@ class PaymentController extends Controller
                     'callback_no' => (string) $callbackNo,
                 ]);
                 PaymentMetrics::inc('order.late_paid.reopened');
+                $this->notifyAdminsLatePayment($orderService->order, $callbackNo, 'reopened', true);
                 HookManager::call('payment.notify.success', $orderService->order);
                 return true;
             case 'duplicate':
@@ -173,6 +193,33 @@ class PaymentController extends Controller
         ];
         PaymentMetrics::warn('order.late_paid.manual_review', $context);
         Log::error('[late-payment] 已取消/非常规状态订单收到真实支付，无法安全自动开通，需人工处理', $context);
+        $this->notifyAdminsLatePayment($order, $callbackNo, $reason);
         return true;
+    }
+
+    /**
+     * 迟到支付事件推送 Telegram 管理员。sendMessageWithAdmin 只查库并派发队列任务，
+     * 真正的 HTTP 发送在队列 worker 中完成；本方法整体 try/catch，任何失败（含 Bot
+     * 未配置、队列不可用）都不影响向网关 ACK。
+     */
+    private function notifyAdminsLatePayment(Order $order, $callbackNo, string $reason, bool $reopened = false): void
+    {
+        try {
+            $amount = number_format(((int) $order->total_amount) / 100, 2);
+            $message = ($reopened
+                ? "✅ 已取消订单收到真实支付，已自动恢复开通\n"
+                : "⚠️ 迟到支付需人工处理\n")
+                . "订单号：{$order->trade_no}\n"
+                . "用户ID：{$order->user_id}\n"
+                . "金额：¥{$amount}\n"
+                . "回调流水：{$callbackNo}"
+                . ($reopened ? '' : "\n原因：{$reason}");
+            (new TelegramService())->sendMessageWithAdmin($message);
+        } catch (\Throwable $e) {
+            try {
+                Log::warning('[late-payment] Telegram 通知发送失败', ['message' => $e->getMessage()]);
+            } catch (\Throwable $ignored) {
+            }
+        }
     }
 }

--- a/app/Services/OrderService.php
+++ b/app/Services/OrderService.php
@@ -21,6 +21,14 @@ class OrderService
 {
     private const BYTES_PER_GB = 1073741824;
 
+    /**
+     * 迟到支付自动复活的最大迟到窗口（秒）。
+     * 网关收款会话存活期是分钟级（BEpusdt 默认 10 分钟、易支付类同量级），正常迟到
+     * 支付都发生在下单后极短时间内；超过该窗口的「复活」更可能是重放或异常场景，
+     * 且折抵快照的价值漂移开始不可忽略，一律转人工。
+     */
+    private const REOPEN_MAX_LATE_SECONDS = 86400;
+
     const STR_TO_TIME = [
         Plan::PERIOD_MONTHLY => 1,
         Plan::PERIOD_QUARTERLY => 3,
@@ -133,8 +141,22 @@ class OrderService
             }
 
             if ($order->surplus_order_ids) {
-                Order::whereIn('id', $order->surplus_order_ids)
+                $surplusIds = array_values(array_filter(array_map('intval', (array) $order->surplus_order_ids)));
+                // 条件更新：只允许「已完成 → 已折抵」。affected 数不足说明部分折抵源
+                // 已被其他订单折抵（典型：取消单复活与重下的新单引用同一批折抵源，
+                // 先开通的一单消耗后另一单又完成支付）。此时继续开通等于同一批旧订单
+                // 的剩余价值被折抵两次，必须中止转人工；事务回滚不留半套状态。
+                $marked = Order::whereIn('id', $surplusIds)
+                    ->where('status', Order::STATUS_COMPLETED)
                     ->update(['status' => Order::STATUS_DISCOUNTED]);
+                if ($marked !== count($surplusIds)) {
+                    PaymentMetrics::warn('order.open.surplus_conflict', [
+                        'trade_no' => (string) $order->trade_no,
+                        'expected' => count($surplusIds),
+                        'marked' => (int) $marked,
+                    ]);
+                    throw new \RuntimeException('折抵源订单状态已变化（疑似重复折抵），中止自动开通转人工');
+                }
             }
 
             match ((string) $order->period) {
@@ -481,16 +503,24 @@ class OrderService
     }
 
     /**
-     * 已取消订单收到真实迟到支付后，在严格安全条件下重新开通。
+     * 已取消订单收到真实迟到支付后，复核下单时占用的资源并重新开通。
      *
-     * 只自动重开「干净」订单——cancel() 唯一会反向的操作是「退还 balance_amount」和
-     * 「恢复优惠券用量」，因此对没有余额抵扣、没有优惠券、没有套餐折抵/变更的订单，
-     * cancel() 实际上没有释放任何资源，重开与它完全对称，绝不会造成少扣款或优惠券二次使用。
-     * 其余订单一律返回 'manual' 交人工处理，避免制造不一致或漏洞。
+     * cancel() 会反向释放的资源有：退还 balance_amount、恢复优惠券用量；套餐折抵
+     * （surplus_order_ids）虽在 open() 才真正消耗，但取消后折抵源可能已被后续订单
+     * 折抵。重开的原则是「先复核、再占用、后翻状态」，任一资源无法完整恢复到下单
+     * 时的占用状态就返回 'manual' 交人工，绝不部分开通：
+     *   - 折抵源订单必须仍全部处于「已完成」（行锁防并发）；
+     *   - 余额抵扣需用户当前余额仍足够，重新扣回；
+     *   - 优惠券配额需仍可原子占用（全局 limit_use 条件扣减 + 每人限用复核）。
+     *     券的时间窗不复核：用户在券有效期内下的单、按折后价真实付了款，迟到只是
+     *     网关结算延迟，重占配额即可，不没收既定折扣。
+     *
+     * 所有只读校验先于所有写入执行；写入阶段的意外失败一律抛异常整体回滚，落入
+     * 'error' 分支（与 'manual' 一样会转人工告警），不会留下半套状态。
      *
      * 安全性说明：本方法只在回调签名已由订单绑定网关验过之后（PaymentController::handle
-     * 上游）才会被调用，且调用前已强制校验回调网关 == 订单 payment_id，因此攻击者无法为
-     * 他人订单触发重开，只能重开自己真实支付过的订单。
+     * 上游）才会被调用，且调用前已强制校验回调网关与订单 payment_id 同源，因此攻击者
+     * 无法为他人订单触发重开，只能重开自己真实支付过的订单。
      *
      * @return string 'reopened' | 'duplicate' | 'manual' | 'missing' | 'unexpected' | 'error'
      */
@@ -513,16 +543,8 @@ class OrderService
                     return 'unexpected';
                 }
 
-                // 安全闸门 A：只重开「干净」订单。
-                //   balance_amount：cancel() 已退回用户余额，重开需重新扣除，但余额可能已被花掉 → 人工。
-                //   coupon_id：    cancel() 已恢复优惠券用量，重开需重新占用，但券可能已过期/用尽 → 人工。
-                //   surplus/UPGRADE：套餐折抵/变更依赖创建时快照，此刻可能已陈旧 → 人工。
-                if (
-                    (int) ($locked->balance_amount ?? 0) !== 0
-                    || $locked->coupon_id !== null
-                    || !empty($locked->surplus_order_ids)
-                    || (int) $locked->type === Order::TYPE_UPGRADE
-                ) {
+                // 安全闸门 0：迟到窗口，超过上限的复活转人工（见常量注释）。
+                if (time() - (int) $locked->created_at > self::REOPEN_MAX_LATE_SECONDS) {
                     return 'manual';
                 }
 
@@ -538,6 +560,74 @@ class OrderService
                 // 安全闸门 C：套餐仍存在。
                 if (!Plan::find($locked->plan_id)) {
                     return 'manual';
+                }
+
+                // ── 安全闸门 A：复核并重新占用下单时的资源（先只读校验，后统一写入）──
+
+                // A1 套餐折抵：折抵源订单必须仍全部「已完成」。若已被其他订单折抵
+                // （典型：用户取消本单后重下一单引用同一批折抵源且已开通）或被撤销，
+                // 创建时的折抵快照失效 → 人工。行锁串行化与并发 open() 的竞争；真正
+                // 翻成 DISCOUNTED 由本单后续 open() 在同样的条件守卫下完成。
+                $surplusIds = array_values(array_filter(array_map('intval', (array) ($locked->surplus_order_ids ?? []))));
+                if (!empty($surplusIds)) {
+                    $stillCompleted = Order::whereIn('id', $surplusIds)
+                        ->where('status', Order::STATUS_COMPLETED)
+                        ->lockForUpdate()
+                        ->count();
+                    if ($stillCompleted !== count($surplusIds)) {
+                        return 'manual';
+                    }
+                }
+
+                // A2 余额抵扣（只读校验）：cancel() 已退回余额，重开需重新扣除；
+                // 余额可能已被花掉，先锁用户行校验充足性。
+                $balanceAmount = (int) ($locked->balance_amount ?? 0);
+                if ($balanceAmount < 0) {
+                    return 'manual'; // 异常数据，不自动处理
+                }
+                $lockedUser = User::lockForUpdate()->find($locked->user_id);
+                if (!$lockedUser) {
+                    return 'manual';
+                }
+                if ($balanceAmount > 0 && (int) $lockedUser->balance < $balanceAmount) {
+                    return 'manual';
+                }
+
+                // A3 优惠券：cancel() 已恢复用量，重开需重新占用。券被删除 → 人工；
+                // 每人限用按当前非待付/非取消订单数复核（本单此刻仍是 CANCELLED，不计入）；
+                // 全局配额用条件 UPDATE 原子扣减，抢不到 → 人工。该扣减虽是写入，但失败
+                // 即 affected=0 且不产生任何变更，放在只读校验末尾是安全的。
+                if ($locked->coupon_id !== null) {
+                    $coupon = Coupon::lockForUpdate()->find($locked->coupon_id);
+                    if (!$coupon) {
+                        return 'manual';
+                    }
+                    if ($coupon->limit_use_with_user !== null) {
+                        $usedCount = Order::where('coupon_id', $coupon->id)
+                            ->where('user_id', $locked->user_id)
+                            ->whereNotIn('status', [Order::STATUS_PENDING, Order::STATUS_CANCELLED])
+                            ->count();
+                        if ($usedCount >= (int) $coupon->limit_use_with_user) {
+                            return 'manual';
+                        }
+                    }
+                    if ($coupon->limit_use !== null) {
+                        $affected = Coupon::where('id', $coupon->id)
+                            ->where('limit_use', '>', 0)
+                            ->decrement('limit_use');
+                        if ($affected === 0) {
+                            return 'manual';
+                        }
+                    }
+                }
+
+                // ── 写入阶段：以下失败均抛异常，整体回滚（含上面的优惠券扣减）──
+
+                if ($balanceAmount > 0) {
+                    $lockedUser->balance = (int) $lockedUser->balance - $balanceAmount;
+                    if (!$lockedUser->save()) {
+                        throw new \RuntimeException('re-deduct balance failed');
+                    }
                 }
 
                 $locked->status = Order::STATUS_PROCESSING;

--- a/tests/Feature/LatePaymentReopenTest.php
+++ b/tests/Feature/LatePaymentReopenTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Models\Coupon;
 use App\Models\Order;
 use App\Models\Plan;
 use App\Models\User;
@@ -11,13 +12,16 @@ use Illuminate\Support\Str;
 use Tests\TestCase;
 
 /**
- * P1-10 回归测试：已取消订单收到真实迟到支付时的**安全**重开。
+ * 回归测试：已取消订单收到真实迟到支付时的**安全**重开。
  *
- * 安全边界（OrderService::reopenFromCancelled）：只自动重开「干净」订单——
- * cancel() 唯一会反向的操作是退还 balance_amount、恢复优惠券用量，因此只有
- * 没有余额抵扣 / 没有优惠券 / 没有套餐折抵 / 非套餐变更的订单，cancel 时才没有释放
- * 任何资源，重开与之完全对称、不会造成少扣款或优惠券二次使用。其余一律转人工，
- * 绝不自动开通（避免制造漏洞）。本测试锁定这些拒绝闸门 + 幂等 + 正向重开。
+ * 安全边界（OrderService::reopenFromCancelled）：重开的原则是「先复核、再占用、
+ * 后翻状态」——cancel() 释放过的资源（余额、优惠券配额）与 open() 才消耗的资源
+ * （套餐折抵源）都必须能完整恢复到下单时的占用状态才放行，任一项复核失败一律
+ * 转人工，绝不部分开通。本测试锁定：
+ *   - 各复核闸门的拒绝路径（资源已不可恢复时不自动开通）；
+ *   - 各复核闸门的放行路径（资源重占后正确开通，且真实扣减）；
+ *   - 幂等 / 状态守卫；
+ *   - open() 的折抵源条件消耗守卫（防同批折抵源被两单重复折抵）。
  */
 class LatePaymentReopenTest extends TestCase
 {
@@ -41,6 +45,18 @@ class LatePaymentReopenTest extends TestCase
         ], $overrides));
     }
 
+    private function makePlan(array $overrides = []): Plan
+    {
+        return Plan::create(array_merge([
+            'group_id' => 1,
+            'transfer_enable' => 100,
+            'name' => 'Test Plan ' . Str::random(6),
+            'speed_limit' => null,
+            'device_limit' => null,
+            'reset_traffic_method' => 2, // 不重置，避免测试触及周期重置细节
+        ], $overrides));
+    }
+
     private function makeCancelledOrder(array $overrides = []): Order
     {
         return Order::create(array_merge([
@@ -55,68 +71,222 @@ class LatePaymentReopenTest extends TestCase
         ], $overrides));
     }
 
-    private function reopen(Order $order): string
+    private function makeCompletedOrder(int $userId, array $overrides = []): Order
     {
-        return (new OrderService($order))->reopenFromCancelled('CB-' . Str::random(8));
-    }
-
-    // ---- 安全闸门 A：非「干净」订单一律转人工，不自动重开 ----
-
-    public function test_reopen_rejects_order_with_balance_amount(): void
-    {
-        // 余额抵扣已在 cancel 时退回用户，重开需重新扣除但余额可能已花掉 → 人工
-        $order = $this->makeCancelledOrder(['balance_amount' => 500]);
-
-        $this->assertSame('manual', $this->reopen($order));
-        $this->assertSame(Order::STATUS_CANCELLED, (int) $order->fresh()->status);
-    }
-
-    public function test_reopen_rejects_order_with_coupon(): void
-    {
-        // 优惠券用量已在 cancel 时恢复，重开需重新占用但券可能已过期/用尽 → 人工
-        $order = $this->makeCancelledOrder(['coupon_id' => 7]);
-
-        $this->assertSame('manual', $this->reopen($order));
-        $this->assertSame(Order::STATUS_CANCELLED, (int) $order->fresh()->status);
-    }
-
-    public function test_reopen_rejects_order_with_surplus(): void
-    {
-        // 套餐折抵依赖创建时快照，此刻可能已陈旧 → 人工
-        $order = $this->makeCancelledOrder(['surplus_order_ids' => [10, 11]]);
-
-        $this->assertSame('manual', $this->reopen($order));
-        $this->assertSame(Order::STATUS_CANCELLED, (int) $order->fresh()->status);
-    }
-
-    public function test_reopen_rejects_plan_change_order(): void
-    {
-        // 套餐变更（UPGRADE）逻辑复杂且依赖旧订阅状态 → 人工
-        $order = $this->makeCancelledOrder(['type' => Order::TYPE_UPGRADE]);
-
-        $this->assertSame('manual', $this->reopen($order));
-        $this->assertSame(Order::STATUS_CANCELLED, (int) $order->fresh()->status);
-    }
-
-    // ---- 安全闸门 B：用户已有更晚的开通/完成订单，重开会覆盖当前订阅 → 人工 ----
-
-    public function test_reopen_rejects_when_user_has_newer_active_order(): void
-    {
-        $user = $this->makeUser();
-        $cancelled = $this->makeCancelledOrder(['user_id' => $user->id]);
-        // 更晚（id 更大）且已完成的订单
-        Order::create([
-            'user_id' => $user->id,
+        return Order::create(array_merge([
+            'user_id' => $userId,
             'plan_id' => 1,
             'period' => Plan::PERIOD_MONTHLY,
             'trade_no' => Str::upper(Str::random(16)),
             'total_amount' => 1000,
             'type' => Order::TYPE_NEW_PURCHASE,
             'status' => Order::STATUS_COMPLETED,
+        ], $overrides));
+    }
+
+    private function makeCoupon(array $overrides = []): Coupon
+    {
+        return Coupon::create(array_merge([
+            'code' => Str::upper(Str::random(8)),
+            'name' => 'Test Coupon',
+            'type' => 1,
+            'value' => 100,
+            'started_at' => time() - 3600,
+            'ended_at' => time() + 3600,
+        ], $overrides));
+    }
+
+    private function reopen(Order $order): string
+    {
+        return (new OrderService($order))->reopenFromCancelled('CB-' . Str::random(8));
+    }
+
+    // ---- 闸门 0：迟到窗口 ----
+
+    public function test_reopen_rejects_stale_late_payment(): void
+    {
+        // 超过 24h 的「复活」更可能是重放/异常，且折抵快照漂移不可忽略 → 人工
+        $plan = $this->makePlan();
+        $order = $this->makeCancelledOrder([
+            'plan_id' => $plan->id,
+            'created_at' => time() - 2 * 86400,
         ]);
+
+        $this->assertSame('manual', $this->reopen($order));
+        $this->assertSame(Order::STATUS_CANCELLED, (int) $order->fresh()->status);
+    }
+
+    // ---- 闸门 B：用户已有更晚的开通/完成订单，重开会覆盖当前订阅 → 人工 ----
+
+    public function test_reopen_rejects_when_user_has_newer_active_order(): void
+    {
+        $user = $this->makeUser();
+        $cancelled = $this->makeCancelledOrder(['user_id' => $user->id]);
+        // 更晚（id 更大）且已完成的订单
+        $this->makeCompletedOrder($user->id);
 
         $this->assertSame('manual', $this->reopen($cancelled));
         $this->assertSame(Order::STATUS_CANCELLED, (int) $cancelled->fresh()->status);
+    }
+
+    // ---- 闸门 C：套餐已被删除 → 人工 ----
+
+    public function test_reopen_rejects_when_plan_missing(): void
+    {
+        $order = $this->makeCancelledOrder(['plan_id' => 99999]);
+
+        $this->assertSame('manual', $this->reopen($order));
+        $this->assertSame(Order::STATUS_CANCELLED, (int) $order->fresh()->status);
+    }
+
+    // ---- 闸门 A1：套餐折抵源复核 ----
+
+    public function test_reopen_rejects_when_surplus_source_missing(): void
+    {
+        // 折抵源订单不存在（数据异常）→ 人工
+        $plan = $this->makePlan();
+        $order = $this->makeCancelledOrder([
+            'plan_id' => $plan->id,
+            'surplus_order_ids' => [98765, 98766],
+        ]);
+
+        $this->assertSame('manual', $this->reopen($order));
+        $this->assertSame(Order::STATUS_CANCELLED, (int) $order->fresh()->status);
+    }
+
+    public function test_reopen_rejects_when_surplus_source_already_discounted(): void
+    {
+        // 折抵源已被其他订单折抵（典型：取消后重下的新单已开通）→ 人工，不双重折抵
+        $plan = $this->makePlan();
+        $user = $this->makeUser();
+        $intact = $this->makeCompletedOrder($user->id);
+        $consumed = $this->makeCompletedOrder($user->id, ['status' => Order::STATUS_DISCOUNTED]);
+        $order = $this->makeCancelledOrder([
+            'user_id' => $user->id,
+            'plan_id' => $plan->id,
+            'type' => Order::TYPE_UPGRADE,
+            'surplus_order_ids' => [$intact->id, $consumed->id],
+        ]);
+
+        $this->assertSame('manual', $this->reopen($order));
+        $this->assertSame(Order::STATUS_CANCELLED, (int) $order->fresh()->status);
+        // 完好的折抵源不能被部分消耗
+        $this->assertSame(Order::STATUS_COMPLETED, (int) $intact->fresh()->status);
+    }
+
+    public function test_reopen_activates_upgrade_order_and_consumes_surplus(): void
+    {
+        // 折抵源仍全部完好的套餐变更单：复活并正确消耗折抵源（本次生产事故的核心场景）
+        $plan = $this->makePlan();
+        $user = $this->makeUser(['plan_id' => $plan->id, 'expired_at' => time() + 86400]);
+        $source = $this->makeCompletedOrder($user->id);
+        $order = $this->makeCancelledOrder([
+            'user_id' => $user->id,
+            'plan_id' => $plan->id,
+            'type' => Order::TYPE_UPGRADE,
+            'surplus_order_ids' => [$source->id],
+        ]);
+
+        $this->assertSame('reopened', $this->reopen($order));
+        $this->assertSame(Order::STATUS_COMPLETED, (int) $order->fresh()->status);
+        $this->assertSame(Order::STATUS_DISCOUNTED, (int) $source->fresh()->status);
+
+        $user->refresh();
+        $this->assertSame($plan->id, (int) $user->plan_id);
+        $this->assertGreaterThan(time(), (int) $user->expired_at);
+    }
+
+    // ---- 闸门 A2：余额抵扣复核 ----
+
+    public function test_reopen_rejects_when_balance_insufficient(): void
+    {
+        // cancel() 已退回余额且用户已花掉 → 无法重新扣除 → 人工
+        $plan = $this->makePlan();
+        $user = $this->makeUser(['balance' => 300]);
+        $order = $this->makeCancelledOrder([
+            'user_id' => $user->id,
+            'plan_id' => $plan->id,
+            'balance_amount' => 500,
+        ]);
+
+        $this->assertSame('manual', $this->reopen($order));
+        $this->assertSame(Order::STATUS_CANCELLED, (int) $order->fresh()->status);
+        $this->assertSame(300, (int) $user->fresh()->balance);
+    }
+
+    public function test_reopen_rededucts_balance_when_sufficient(): void
+    {
+        $plan = $this->makePlan();
+        $user = $this->makeUser(['balance' => 800]);
+        $order = $this->makeCancelledOrder([
+            'user_id' => $user->id,
+            'plan_id' => $plan->id,
+            'balance_amount' => 500,
+        ]);
+
+        $this->assertSame('reopened', $this->reopen($order));
+        $this->assertSame(Order::STATUS_COMPLETED, (int) $order->fresh()->status);
+        $this->assertSame(300, (int) $user->fresh()->balance);
+    }
+
+    // ---- 闸门 A3：优惠券配额复核 ----
+
+    public function test_reopen_rejects_when_coupon_deleted(): void
+    {
+        $plan = $this->makePlan();
+        $order = $this->makeCancelledOrder([
+            'plan_id' => $plan->id,
+            'coupon_id' => 99999,
+        ]);
+
+        $this->assertSame('manual', $this->reopen($order));
+        $this->assertSame(Order::STATUS_CANCELLED, (int) $order->fresh()->status);
+    }
+
+    public function test_reopen_rejects_when_coupon_quota_exhausted(): void
+    {
+        $plan = $this->makePlan();
+        $coupon = $this->makeCoupon(['limit_use' => 0]);
+        $order = $this->makeCancelledOrder([
+            'plan_id' => $plan->id,
+            'coupon_id' => $coupon->id,
+        ]);
+
+        $this->assertSame('manual', $this->reopen($order));
+        $this->assertSame(Order::STATUS_CANCELLED, (int) $order->fresh()->status);
+        $this->assertSame(0, (int) $coupon->fresh()->limit_use);
+    }
+
+    public function test_reopen_rejects_when_coupon_over_per_user_limit(): void
+    {
+        // 取消期间用户已用同一张券完成了别的订单，重占会超每人限用 → 人工。
+        // 注意先创建已完成订单再创建取消单，避免误触闸门 B（更晚的已完成订单）。
+        $plan = $this->makePlan();
+        $user = $this->makeUser();
+        $coupon = $this->makeCoupon(['limit_use' => null, 'limit_use_with_user' => 1]);
+        $this->makeCompletedOrder($user->id, ['coupon_id' => $coupon->id]);
+        $order = $this->makeCancelledOrder([
+            'user_id' => $user->id,
+            'plan_id' => $plan->id,
+            'coupon_id' => $coupon->id,
+        ]);
+
+        $this->assertSame('manual', $this->reopen($order));
+        $this->assertSame(Order::STATUS_CANCELLED, (int) $order->fresh()->status);
+    }
+
+    public function test_reopen_reoccupies_coupon_quota(): void
+    {
+        $plan = $this->makePlan();
+        $coupon = $this->makeCoupon(['limit_use' => 5]);
+        $order = $this->makeCancelledOrder([
+            'plan_id' => $plan->id,
+            'coupon_id' => $coupon->id,
+        ]);
+
+        $this->assertSame('reopened', $this->reopen($order));
+        $this->assertSame(Order::STATUS_COMPLETED, (int) $order->fresh()->status);
+        $this->assertSame(4, (int) $coupon->fresh()->limit_use);
     }
 
     // ---- 幂等 / 状态守卫 ----
@@ -140,14 +310,7 @@ class LatePaymentReopenTest extends TestCase
 
     public function test_reopen_activates_clean_order(): void
     {
-        $plan = Plan::create([
-            'group_id' => 1,
-            'transfer_enable' => 100,
-            'name' => 'Test Plan',
-            'speed_limit' => null,
-            'device_limit' => null,
-            'reset_traffic_method' => 2, // 不重置，避免测试触及周期重置细节
-        ]);
+        $plan = $this->makePlan();
         $user = $this->makeUser(['plan_id' => null, 'expired_at' => 0]);
 
         $order = $this->makeCancelledOrder([
@@ -166,5 +329,32 @@ class LatePaymentReopenTest extends TestCase
         $user->refresh();
         $this->assertSame($plan->id, (int) $user->plan_id);
         $this->assertGreaterThan(time(), (int) $user->expired_at);
+    }
+
+    // ---- open() 的折抵源条件消耗守卫 ----
+
+    public function test_open_aborts_when_surplus_source_not_completed(): void
+    {
+        // 同批折抵源被另一单抢先消耗后，本单 open() 必须中止而非双重折抵
+        $plan = $this->makePlan();
+        $user = $this->makeUser(['plan_id' => $plan->id, 'expired_at' => time() + 86400]);
+        $consumed = $this->makeCompletedOrder($user->id, ['status' => Order::STATUS_DISCOUNTED]);
+        $order = $this->makeCancelledOrder([
+            'user_id' => $user->id,
+            'plan_id' => $plan->id,
+            'status' => Order::STATUS_PROCESSING,
+            'surplus_order_ids' => [$consumed->id],
+        ]);
+
+        try {
+            (new OrderService($order))->open();
+            $this->fail('open() 应在折抵源状态异常时中止');
+        } catch (\RuntimeException $e) {
+            $this->assertStringContainsString('折抵', $e->getMessage());
+        }
+
+        // 事务整体回滚：订单停留在开通中，等待人工处理
+        $this->assertSame(Order::STATUS_PROCESSING, (int) $order->fresh()->status);
+        $this->assertSame(Order::STATUS_DISCOUNTED, (int) $consumed->fresh()->status);
     }
 }


### PR DESCRIPTION
## 背景

生产环境发生一类迟到支付事故：支付网关 create-order 接口超时，用户等待无果后误以为支付挂死，取消订单并重新下单，但实际付款落在了**第一笔（已取消）订单**的网关收款会话上。回调到达时订单已是 CANCELLED；由于该单是「套餐变更 + 折抵单」，`reopenFromCancelled()` 的安全闸门 A 一刀切判 `manual`，而 manual_review 只写日志无告警，直到客户投诉才被人工发现补单。另有一单因同一易支付商户拆多通道导致 `gateway_mismatch` 转人工后长期无人处理。

链上/扫码支付无法阻止用户向已展示的收款凭据付款，因此根治方向不是"关收款单"，而是**让真实到账的迟到支付能安全自愈**。

## 改动

### 1. `reopenFromCancelled()`：从「一刀切转人工」改为「复核后放行」

原闸门 A 对余额抵扣/优惠券/折抵/变更单一律 `manual`。现改为逐项复核并重新占用下单时的资源，任一项无法完整恢复才转人工：

- **折抵源**（A1）：全部折抵源订单必须仍为 COMPLETED（行锁校验）；已被其他订单折抵 → manual
- **余额抵扣**（A2）：锁用户行校验余额充足则重扣；已花掉 → manual
- **优惠券**（A3）：全局配额原子重占（条件 UPDATE）+ 每人限用复核；券删除/配额尽/超限 → manual。券的时间窗不复核——用户在有效期内下的单、按折后价真实付了款，不没收既定折扣
- **新增闸门 0**：迟到超 24h 转人工（网关会话存活期是分钟级，超窗更可能是重放/异常）

所有只读校验先于写入；写入失败抛异常整体回滚，绝不部分开通。原闸门 B（更晚活跃订单）、C（套餐存在）保留。

### 2. `open()`：折抵消耗加条件守卫（防双重折抵）

`surplus_order_ids → DISCOUNTED` 改为条件更新（仅 COMPLETED→DISCOUNTED），affected 数不符即中止开通并告警。堵住「取消单复活 + 重下的新单引用同一批折抵源，两单都完成支付则折抵两次」的套利路径。

### 3. 迟到支付 Telegram 管理员告警

`manual_review` 与自动复活成功都推送 `sendMessageWithAdmin`（查库 + 派发队列任务，整体 try/catch，不影响回调 ACK）。此前只有日志，无人值守时事故长期不被发现。

### 4. 同商户多通道等价（gateway_mismatch 放宽）

同一易支付商户拆「支付宝」「微信」两条 Payment 记录时，用户 checkout 后切换支付方式会改写 `payment_id`，随后支付第一条通道的收款码，合法回调必然 mismatch。现将「同插件类」视为同源：

- 迟到支付路径：同插件类不同记录 → 放行并记 `gateway_family_match` 指标
- pending 路径：enforce 模式只拦跨插件回调（同插件类保持 warn 记录）

回调签名已在上游用接收 uuid 的凭证验过；同插件类等价不弱于 pending 路径默认 warn 模式的既有行为。

## 测试

`LatePaymentReopenTest` 重写为 16 用例（42 断言），覆盖各闸门拒绝/放行路径、幂等、open() 守卫，全绿；全量套件与 main 基线对比零新增失败（既有 DeviceStateConsistencyTest 的 10 个环境性 error 在 main 上同样存在）。

注：本套件需要 MySQL + Redis（迁移含 `SHOW INDEX` 等 MySQL 专用语句；`config/database.php` 的 sqlite `database` 字段包了 `base_path()`，`:memory:` 会落成磁盘文件并触发 WAL 锁死）。本地可用一次性容器运行：

```bash
docker network create xbtest
docker run -d --rm --name xbtest-mysql --network xbtest -e MYSQL_ROOT_PASSWORD=test -e MYSQL_DATABASE=xbtest mysql:8.4
docker run -d --rm --name xbtest-redis --network xbtest redis:7-alpine
docker run --rm --network xbtest -e DB_CONNECTION=mysql -e DB_HOST=xbtest-mysql \
  -e DB_DATABASE=xbtest -e DB_USERNAME=root -e DB_PASSWORD=test \
  -e REDIS_HOST=xbtest-redis -e REDIS_PORT=6379 -e REDIS_PASSWORD= \
  -v "$PWD:/repo" -w /repo --entrypoint sh <app-image> -c 'vendor/bin/phpunit --no-coverage'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
